### PR TITLE
locked version of json2csv at 4.2.0 and cleaned up package.json

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file-assets",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A set of processors for exporting data to files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,11 +1,11 @@
 {
   "name": "file-assets",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A set of processors for exporting data to files",
   "main": "index.js",
   "dependencies": {
     "bluebird": "^3.5.1",
-    "json2csv": "^4.2.0"
+    "json2csv": "4.2.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-assets",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Teraslice processors for working with data stored in files on disk",
   "main": "index.js",
   "repository": "https://github.com/terascope/file-assets.git",
@@ -13,15 +13,13 @@
     "report-coverage": "nyc report --reporter=text-lcov > coverage/coverage.lcov && codecov"
   },
   "devDependencies": {
-    "@terascope/teraslice-op-test-harness": "^1.0.0",
+    "@terascope/teraslice-op-test-harness": "^1.1.1",
     "bluebird": "^3.5.1",
     "codecov": "^3.0.4",
-    "eslint": "^4.19.1",
+    "eslint": "^5.5.0",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-import": "^2.12.0",
-    "json2csv": "^4.2.0"
-  },
-  "devDependencies": {
+    "json2csv": "4.2.0",
     "lodash": "^4.17.10"
   }
 }


### PR DESCRIPTION
json2csv `v4.2.1` breaks all of the tests for the file exporter, so the version is being locked until a fix is worked out for the newer version