### PR TITLE
fixed file exporter file_per_slice numbering

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file-assets",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "A set of processors for exporting data to files"
 }

--- a/asset/file_exporter/index.js
+++ b/asset/file_exporter/index.js
@@ -37,7 +37,7 @@ function newProcessor(context, opConfig) {
     }
 
     // Determines the filname based on the settings
-    function getFilename(options) {
+    function getFilename() {
         if (filePerSlice) {
             // Increment the file number tracker by one and use the previous number
             fileNum += 1;
@@ -46,9 +46,9 @@ function newProcessor(context, opConfig) {
         // Make sure header does not show up mid-file if the worker is writing all slices to a
         // single file
         if (!firstSlice) {
-            options.header = false;
-            firstSlice = false;
+            csvOptions.header = false;
         }
+        firstSlice = false;
         return filenameBase;
     }
 
@@ -78,8 +78,7 @@ function newProcessor(context, opConfig) {
                 throw new Error('Unsupported output format!!');
             }
         }
-
-        return fs.appendFileAsync(getFilename(csvOptions), buildOutputString(data))
+        return fs.appendFileAsync(getFilename(), buildOutputString(data))
             .catch((err) => {
                 throw new Error(err);
             });

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-assets",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A set of processors for working with files",
   "dependencies": {
     "@terascope/chunked-file-reader": "^1.0.0",
@@ -19,6 +19,6 @@
     "type": "git",
     "url": "git+https://github.com/terascope/file-assets.git"
   },
-  "author": "zach",
+  "author": "@macgyver603",
   "license": "ISC"
 }


### PR DESCRIPTION
Rejiggered the file numbering for the `file_per_slice` setting to work for as many slices as need. It now just uses a counter the worker keeps in memory instead of listing the files in the output directory and comparing them all for every single slice.

addresses #22