### PR TITLE
rejiggered s3 reader for better error handling

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file-assets",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "A set of processors for exporting data to files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-assets",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "A set of processors for working with files",
     "dependencies": {
         "@terascope/chunked-file-reader": "^2.1.6",

--- a/test/s3_reader/slicer-spec.js
+++ b/test/s3_reader/slicer-spec.js
@@ -82,15 +82,11 @@ describe('S3 slicer when slicing JSON objects', () => {
     });
 
     it('should generate whole-object slices.', async () => {
-        const slices = [];
-        async function getSlices() {
-            const results = await harness.createSlices();
-            if (results[0]) {
-                slices.push(results[0]);
-                await getSlices();
-            }
-        }
-        await getSlices();
+        // Expecting a truncated response, so we need to call slice() twice
+        const firstBatch = await harness.createSlices();
+        const secondBatch = await harness.createSlices();
+        const slices = firstBatch.concat(secondBatch);
+
         expect(slices.length).toBe(6);
 
         // Verify the S3 request parameters are accurate
@@ -174,15 +170,7 @@ describe('S3 slicer when slicing other objects', () => {
     });
 
     it('should generate regular slices.', async () => {
-        const slices = [];
-        async function getSlices() {
-            const results = await harness.createSlices();
-            if (results[0]) {
-                slices.push(results[0]);
-                await getSlices();
-            }
-        }
-        await getSlices();
+        const slices = await harness.createSlices();
         expect(slices.length).toBe(4);
 
         let currentRecord = slices.pop();


### PR DESCRIPTION
fixes #164

The S3 reader internal slice queue was removed in favor of adding slices directly to the slice queue maintained with the ES state store, which allowed for better error handling when slicing records.

