### PR TITLE
v0.8.3 - Use node 12 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 language: node_js
 node_js:
   - '10.16'
+  - '12.13'
 os:
   - linux
   - osx
@@ -10,6 +11,9 @@ branches:
   only:
   - master
   - /^v\d+\.\d+\.\d+/
+cache:
+  npm: false
+  yarn: false
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - yarn lint

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file-assets",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "A set of processors for exporting data to files"
 }

--- a/asset/bin/decompress
+++ b/asset/bin/decompress
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+'use strict';
+
 if (process.env.TEST_EXIT_CODE) {
     process.stderr.write('test failure');
     process.exit(process.env.TEST_EXIT_CODE);

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-assets",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "A set of processors for working with files",
     "dependencies": {
         "@terascope/chunked-file-reader": "^2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-assets-bundle",
-    "version": "0.8.1",
+    "version": "0.8.3",
     "description": "Teraslice processors for working with data stored in files on disk",
     "repository": "https://github.com/terascope/file-assets.git",
     "author": "Terascope, LLC <info@terascope.io>",


### PR DESCRIPTION
Add node 12 tests to UI, but I was unable to install the NPM package [lz4](https://github.com/pierrec/node-lz4) locally using node 12 so we should hold off until that gets fixed.