### PR TITLE
set file_per_slice default to false 

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "0.14.2",
+    "version": "0.14.3",
     "description": "A set of processors for exporting data to files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file",
-    "version": "0.14.2",
+    "version": "0.14.3",
     "description": "A set of processors for working with files",
     "dependencies": {
         "@terascope/job-components": "^0.33.0",

--- a/asset/src/__lib/common-schema.ts
+++ b/asset/src/__lib/common-schema.ts
@@ -89,7 +89,7 @@ export const commonSchema = {
     },
     file_per_slice: {
         doc: 'Determines if a new file is created for each slice.',
-        default: true,
+        default: false,
         format: Boolean
     },
     include_header: {

--- a/asset/src/s3_exporter/processor.ts
+++ b/asset/src/s3_exporter/processor.ts
@@ -24,10 +24,11 @@ export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
         this.csvOptions = makeCsvOptions(opConfig);
         const extension = isEmpty(opConfig.extension) ? undefined : opConfig.extension;
 
+        // `filePerSlice` needs to be ignored since you cannot append to S3 objects
         this.nameOptions = {
             filePath: opConfig.path,
             extension,
-            filePerSlice: opConfig.file_per_slice
+            filePerSlice: true
         };
 
         // This will be incremented as the worker processes slices and used as a way to create

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-assets-bundle",
-    "version": "0.14.2",
+    "version": "0.14.3",
     "description": "Teraslice processors for working with data stored in files on disk",
     "repository": "https://github.com/terascope/file-assets.git",
     "author": "Terascope, LLC <info@terascope.io>",


### PR DESCRIPTION
fixes #317 
General default for `file_per_slice` has been set to `false`, but I hardcoded it to `true` in the `s3_exporter` since it does not support multipart uploads. Setting `file_per_slice` to `false` for that processor will just result in workers constantly overriding their previous object upload.