### PR TITLE
v1.3.0

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "A set of processors for exporting data to files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "A set of processors for working with files",
     "private": true,
     "workspaces": {

--- a/asset/src/__lib/common-schema.ts
+++ b/asset/src/__lib/common-schema.ts
@@ -1,6 +1,4 @@
-import {
-    isNumber, AnyObject, isNotNil, DataEncoding
-} from '@terascope/job-components';
+import { isNumber } from '@terascope/job-components';
 import { Compression, Format } from './interfaces';
 
 const readerSchema = {
@@ -40,7 +38,7 @@ export const commonSchema = {
             + 'be treated as a file prefix.\ni.e. "/data/export_" will result in files like'
             + ' "/data/export_hs897f.1079.gz"',
         default: null,
-        format: 'optional_String'
+        format: 'required_String'
     },
     extension: {
         doc: 'A file extension to add to the object name.',
@@ -91,21 +89,12 @@ export const commonSchema = {
     }
 };
 
-export function compareConfig(opConfig: AnyObject, apiConfig: AnyObject): void {
-    if (isNotNil(opConfig.path)) throw new Error('If api is specified on this operation, the parameter path must not be specified in the opConfig');
-    if (
-        isNotNil(apiConfig._dead_letter_action)
-        && isNotNil(opConfig._dead_letter_action)
-        && opConfig._dead_letter_action !== 'throw') {
-        throw new Error(`Cannot have conflicting _dead_letter_action parameters, apiConfig is set to ${apiConfig._dead_letter_action} while opConfig is set to non-default value ${opConfig._dead_letter_action}, it should be set in the api`);
-    }
-
-    if (
-        isNotNil(apiConfig._encoding)
-        && isNotNil(opConfig._encoding)
-        && opConfig._encoding !== DataEncoding.JSON) {
-        throw new Error(`Cannot have conflicting _encoding parameters, apiConfig is set to ${apiConfig._encoding} while opConfig is set to non-default value ${opConfig._encoding}, it should be set in the api`);
-    }
-}
-
 export const fileReaderSchema = Object.assign({}, commonSchema, readerSchema);
+
+export const opSchema = {
+    api_name: {
+        doc: 'name of api to be used by operation',
+        default: null,
+        format: 'optional_String'
+    }
+};

--- a/asset/src/file_exporter/schema.ts
+++ b/asset/src/file_exporter/schema.ts
@@ -1,51 +1,35 @@
-import {
-    ConvictSchema,
-    cloneDeep,
-    AnyObject,
-    isString,
-    getTypeOf,
-    ValidatedJobConfig,
-    isNil,
-    getOpConfig,
-} from '@terascope/job-components';
+import { ConvictSchema, ValidatedJobConfig } from '@terascope/job-components';
 import { FileExporterConfig } from './interfaces';
-import { commonSchema, compareConfig } from '../__lib/common-schema';
+import { opSchema } from '../__lib/common-schema';
 import { DEFAULT_API_NAME } from '../file_sender_api/interfaces';
-
-const clonedSchema = cloneDeep(commonSchema) as AnyObject;
-
-clonedSchema.api_name = {
-    doc: 'name of api to be used by file_exporter',
-    default: DEFAULT_API_NAME,
-    format: (val: unknown): void => {
-        if (!isString(val)) throw new Error(`Invalid parameter api_name, it must be of type string, was given ${getTypeOf(val)}`);
-        if (!val.includes(DEFAULT_API_NAME)) throw new Error(`Invalid parameter api_name, it must be an ${DEFAULT_API_NAME}`);
-    }
-};
-
-export const schema = clonedSchema;
 
 export default class Schema extends ConvictSchema<FileExporterConfig> {
     validateJob(job: ValidatedJobConfig): void {
-        const opConfig = getOpConfig(job, 'file_exporter') as FileExporterConfig | undefined;
-        if (isNil(opConfig)) throw new Error('Could not find opConfig for operation file_exporter');
-        const { api_name, ...apiConfig } = opConfig;
-        if (!Array.isArray(job.apis)) job.apis = [];
-        const FileSenderAPI = job.apis.find((jobApi) => jobApi._name === api_name);
+        let opIndex = 0;
 
-        if (isNil(FileSenderAPI)) {
-            if (isNil(opConfig.path)) throw new Error(`Invalid parameter path, must be of type string, got ${getTypeOf(opConfig.path)}`);
+        const opConfig = job.operations.find((op, ind) => {
+            if (op._op === 'file_exporter') {
+                opIndex = ind;
+                return op;
+            }
+            return false;
+        });
 
-            job.apis.push({
-                _name: DEFAULT_API_NAME,
-                ...apiConfig
-            });
-        } else {
-            compareConfig(opConfig, FileSenderAPI);
-        }
+        if (opConfig == null) throw new Error('Could not find file_exporter operation in jobConfig');
+
+        const {
+            api_name, ...newConfig
+        } = opConfig;
+
+        const apiName = api_name || `${DEFAULT_API_NAME}:${opConfig._op}-${opIndex}`;
+
+        // we set the new apiName back on the opConfig so it can reference the unique name
+        opConfig.api_name = apiName;
+
+        this.ensureAPIFromConfig(apiName, job, newConfig);
     }
 
     build(): Record<string, any> {
-        return clonedSchema;
+        return opSchema;
     }
 }

--- a/asset/src/file_reader/schema.ts
+++ b/asset/src/file_reader/schema.ts
@@ -1,54 +1,35 @@
-import {
-    ConvictSchema,
-    ValidatedJobConfig,
-    getOpConfig,
-    isNil,
-    cloneDeep,
-    AnyObject,
-    isString,
-    getTypeOf,
-    isEmpty
-} from '@terascope/job-components';
+import { ConvictSchema, ValidatedJobConfig } from '@terascope/job-components';
 import { FileReaderConfig } from './interfaces';
-import { fileReaderSchema, compareConfig } from '../__lib/common-schema';
+import { opSchema } from '../__lib/common-schema';
 import { DEFAULT_API_NAME } from '../file_reader_api/interfaces';
-
-const clonedSchema = cloneDeep(fileReaderSchema) as AnyObject;
-
-clonedSchema.api_name = {
-    doc: 'name of api to be used by file_reader',
-    default: DEFAULT_API_NAME,
-    format: (val: unknown): void => {
-        if (!isString(val)) throw new Error(`Invalid parameter api_name, it must be of type string, was given ${getTypeOf(val)}`);
-        if (!val.includes(DEFAULT_API_NAME)) throw new Error(`Invalid parameter api_name, it must be an ${DEFAULT_API_NAME}`);
-    }
-};
-
-export const schema = clonedSchema;
 
 export default class Schema extends ConvictSchema<FileReaderConfig> {
     validateJob(job: ValidatedJobConfig): void {
-        const opConfig = getOpConfig(job, 'file_reader') as FileReaderConfig | undefined;
-        if (isNil(opConfig)) throw new Error('Could not find opConfig for operation file_reader');
-        const { api_name, ...apiConfig } = opConfig;
-        if (!Array.isArray(job.apis)) job.apis = [];
+        let opIndex = 0;
 
-        const FileReaderAPI = job.apis.find((jobApi) => jobApi._name === api_name);
+        const opConfig = job.operations.find((op, ind) => {
+            if (op._op === 'file_reader') {
+                opIndex = ind;
+                return op;
+            }
+            return false;
+        });
 
-        if (isNil(FileReaderAPI)) {
-            if (isNil(opConfig.path)) throw new Error(`Invalid parameter path, must be of type string, got ${getTypeOf(opConfig.path)}`);
+        if (opConfig == null) throw new Error('Could not find file_reader operation in jobConfig');
 
-            job.apis.push({
-                _name: DEFAULT_API_NAME,
-                ...apiConfig
-            });
-        } else {
-            if (!isEmpty(opConfig.extra_args)) throw new Error('If api is specified on this operation, the parameter extra_args must not be specified in the opConfig');
-            compareConfig(opConfig, FileReaderAPI);
-        }
+        const {
+            api_name, ...newConfig
+        } = opConfig;
+
+        const apiName = api_name || `${DEFAULT_API_NAME}:${opConfig._op}-${opIndex}`;
+
+        // we set the new apiName back on the opConfig so it can reference the unique name
+        opConfig.api_name = apiName;
+
+        this.ensureAPIFromConfig(apiName, job, newConfig);
     }
 
     build(): Record<string, any> {
-        return schema;
+        return opSchema;
     }
 }

--- a/asset/src/file_reader_api/schema.ts
+++ b/asset/src/file_reader_api/schema.ts
@@ -1,11 +1,8 @@
 import { ConvictSchema, cloneDeep } from '@terascope/job-components';
-import { schema } from '../file_reader/schema';
+import { fileReaderSchema } from '../__lib/common-schema';
 import { FileReaderAPIConfig } from './interfaces';
 
-const { api_name, ...newSchema } = schema;
-
-const apiSchema = cloneDeep(newSchema);
-apiSchema.path.format = 'required_String';
+const apiSchema = cloneDeep(fileReaderSchema);
 
 export default class Schema extends ConvictSchema<FileReaderAPIConfig> {
     build(): Record<string, any> {

--- a/asset/src/file_sender_api/schema.ts
+++ b/asset/src/file_sender_api/schema.ts
@@ -1,10 +1,8 @@
 import { ConvictSchema, cloneDeep } from '@terascope/job-components';
-import { schema } from '../file_exporter/schema';
 import { FileSenderAPIConfig } from './interfaces';
+import { commonSchema } from '../__lib/common-schema';
 
-const { api_name, ...newSchema } = schema;
-
-const apiSchema = cloneDeep(newSchema);
+const apiSchema = cloneDeep(commonSchema);
 apiSchema.path.format = 'required_String';
 
 export default class Schema extends ConvictSchema<FileSenderAPIConfig> {

--- a/asset/src/hdfs_append/schema.ts
+++ b/asset/src/hdfs_append/schema.ts
@@ -1,51 +1,35 @@
-import {
-    ConvictSchema,
-    cloneDeep,
-    AnyObject,
-    isString,
-    getTypeOf,
-    ValidatedJobConfig,
-    isNil,
-    getOpConfig
-} from '@terascope/job-components';
+import { ConvictSchema, ValidatedJobConfig } from '@terascope/job-components';
 import { HDFSExportConfig } from './interfaces';
 import { DEFAULT_API_NAME } from '../hdfs_sender_api/interfaces';
-import { fileReaderSchema, compareConfig } from '../__lib/common-schema';
-
-const clonedSchema = cloneDeep(fileReaderSchema) as AnyObject;
-
-clonedSchema.api_name = {
-    doc: 'name of api to be used by hdfs_append',
-    default: DEFAULT_API_NAME,
-    format: (val: unknown): void => {
-        if (!isString(val)) throw new Error(`Invalid parameter api_name, it must be of type string, was given ${getTypeOf(val)}`);
-        if (!val.includes(DEFAULT_API_NAME)) throw new Error(`Invalid parameter api_name, it must be an ${DEFAULT_API_NAME}`);
-    }
-};
-
-export const schema = clonedSchema;
+import { opSchema } from '../__lib/common-schema';
 
 export default class Schema extends ConvictSchema<HDFSExportConfig> {
     validateJob(job: ValidatedJobConfig): void {
-        const opConfig = getOpConfig(job, 'hdfs_exporter') as HDFSExportConfig | undefined;
-        if (isNil(opConfig)) throw new Error('Could not find opConfig for operation hdfs_exporter');
-        const { api_name, ...apiConfig } = opConfig;
-        if (!Array.isArray(job.apis)) job.apis = [];
-        const HDFSSenderAPI = job.apis.find((jobApi) => jobApi._name === api_name);
+        let opIndex = 0;
 
-        if (isNil(HDFSSenderAPI)) {
-            if (isNil(opConfig.path)) throw new Error(`Invalid parameter path, must be of type string, got ${getTypeOf(opConfig.path)}`);
+        const opConfig = job.operations.find((op, ind) => {
+            if (op._op === 'hdfs_append') {
+                opIndex = ind;
+                return op;
+            }
+            return false;
+        });
 
-            job.apis.push({
-                _name: DEFAULT_API_NAME,
-                ...apiConfig
-            });
-        } else {
-            compareConfig(opConfig, HDFSSenderAPI);
-        }
+        if (opConfig == null) throw new Error('Could not find hdfs_append operation in jobConfig');
+
+        const {
+            api_name, ...newConfig
+        } = opConfig;
+
+        const apiName = api_name || `${DEFAULT_API_NAME}:${opConfig._op}-${opIndex}`;
+
+        // we set the new apiName back on the opConfig so it can reference the unique name
+        opConfig.api_name = apiName;
+
+        this.ensureAPIFromConfig(apiName, job, newConfig);
     }
 
     build(): Record<string, any> {
-        return fileReaderSchema;
+        return opSchema;
     }
 }

--- a/asset/src/hdfs_reader/schema.ts
+++ b/asset/src/hdfs_reader/schema.ts
@@ -1,59 +1,35 @@
-import {
-    ConvictSchema,
-    ValidatedJobConfig,
-    getOpConfig,
-    isNil,
-    cloneDeep,
-    AnyObject,
-    isString,
-    getTypeOf,
-    isEmpty
-} from '@terascope/job-components';
+import { ConvictSchema, ValidatedJobConfig } from '@terascope/job-components';
 import { HDFSReaderConfig } from './interfaces';
-import { fileReaderSchema, compareConfig } from '../__lib/common-schema';
+import { opSchema } from '../__lib/common-schema';
 import { DEFAULT_API_NAME } from '../hdfs_reader_api/interfaces';
-
-const clonedSchema = cloneDeep(fileReaderSchema) as AnyObject;
-
-clonedSchema.user = {
-    doc: 'User to use when reading the files. Default: "hdfs"',
-    default: 'hdfs',
-    format: 'optional_String'
-};
-
-clonedSchema.api_name = {
-    doc: 'name of api to be used by hdfs_reader',
-    default: DEFAULT_API_NAME,
-    format: (val: unknown): void => {
-        if (!isString(val)) throw new Error(`Invalid parameter api_name, it must be of type string, was given ${getTypeOf(val)}`);
-        if (!val.includes(DEFAULT_API_NAME)) throw new Error(`Invalid parameter api_name, it must be an ${DEFAULT_API_NAME}`);
-    }
-};
-
-export const schema = clonedSchema;
 
 export default class Schema extends ConvictSchema<HDFSReaderConfig> {
     validateJob(job: ValidatedJobConfig): void {
-        const opConfig = getOpConfig(job, 'hdfs_reader') as HDFSReaderConfig | undefined;
-        if (isNil(opConfig)) throw new Error('Could not find opConfig for operation hdfs_reader');
-        const { api_name, ...apiConfig } = opConfig;
-        if (!Array.isArray(job.apis)) job.apis = [];
-        const HDFSReaderAPI = job.apis.find((jobApi) => jobApi._name === api_name);
+        let opIndex = 0;
 
-        if (isNil(HDFSReaderAPI)) {
-            if (isNil(opConfig.path)) throw new Error(`Invalid parameter path, must be of type string, got ${getTypeOf(opConfig.path)}`);
+        const opConfig = job.operations.find((op, ind) => {
+            if (op._op === 'hdfs_reader') {
+                opIndex = ind;
+                return op;
+            }
+            return false;
+        });
 
-            job.apis.push({
-                _name: DEFAULT_API_NAME,
-                ...apiConfig
-            });
-        } else {
-            if (!isEmpty(opConfig.extra_args)) throw new Error('If api is specified on this operation, the parameter extra_args must not be specified in the opConfig');
-            compareConfig(opConfig, HDFSReaderAPI);
-        }
+        if (opConfig == null) throw new Error('Could not find hdfs_reader operation in jobConfig');
+
+        const {
+            api_name, ...newConfig
+        } = opConfig;
+
+        const apiName = api_name || `${DEFAULT_API_NAME}:${opConfig._op}-${opIndex}`;
+
+        // we set the new apiName back on the opConfig so it can reference the unique name
+        opConfig.api_name = apiName;
+
+        this.ensureAPIFromConfig(apiName, job, newConfig);
     }
 
     build(): Record<string, any> {
-        return schema;
+        return opSchema;
     }
 }

--- a/asset/src/hdfs_reader_api/schema.ts
+++ b/asset/src/hdfs_reader_api/schema.ts
@@ -1,14 +1,31 @@
-import { ConvictSchema, cloneDeep } from '@terascope/job-components';
-import { schema } from '../hdfs_reader/schema';
-import { HDFSReaderApiConfig } from './interfaces';
+import {
+    ConvictSchema,
+    cloneDeep,
+    AnyObject,
+    isString,
+    getTypeOf
+} from '@terascope/job-components';
+import { HDFSReaderApiConfig, DEFAULT_API_NAME } from './interfaces';
+import { fileReaderSchema } from '../__lib/common-schema';
 
-const { api_name, ...newSchema } = schema;
+const clonedSchema = cloneDeep(fileReaderSchema) as AnyObject;
 
-const apiSchema = cloneDeep(newSchema);
-apiSchema.path.format = 'required_String';
+clonedSchema.user = {
+    doc: 'User to use when reading the files. Default: "hdfs"',
+    default: 'hdfs',
+    format: 'optional_String'
+};
 
+clonedSchema.api_name = {
+    doc: 'name of api to be used by hdfs_reader',
+    default: DEFAULT_API_NAME,
+    format: (val: unknown): void => {
+        if (!isString(val)) throw new Error(`Invalid parameter api_name, it must be of type string, was given ${getTypeOf(val)}`);
+        if (!val.includes(DEFAULT_API_NAME)) throw new Error(`Invalid parameter api_name, it must be an ${DEFAULT_API_NAME}`);
+    }
+};
 export default class Schema extends ConvictSchema<HDFSReaderApiConfig> {
     build(): Record<string, any> {
-        return apiSchema;
+        return clonedSchema;
     }
 }

--- a/asset/src/hdfs_sender_api/schema.ts
+++ b/asset/src/hdfs_sender_api/schema.ts
@@ -1,14 +1,9 @@
-import { ConvictSchema, cloneDeep } from '@terascope/job-components';
+import { ConvictSchema } from '@terascope/job-components';
 import { HDFSExporterAPIConfig } from './interfaces';
-import { schema } from '../s3_exporter/schema';
-
-const { api_name, ...newSchema } = schema;
-
-const apiSchema = cloneDeep(newSchema);
-apiSchema.path.format = 'required_String';
+import { fileReaderSchema } from '../__lib/common-schema';
 
 export default class Schema extends ConvictSchema<HDFSExporterAPIConfig> {
     build(): Record<string, any> {
-        return apiSchema;
+        return fileReaderSchema;
     }
 }

--- a/asset/src/s3_exporter/schema.ts
+++ b/asset/src/s3_exporter/schema.ts
@@ -1,51 +1,35 @@
-import {
-    ConvictSchema,
-    cloneDeep,
-    AnyObject,
-    isString,
-    getTypeOf,
-    ValidatedJobConfig,
-    isNil,
-    getOpConfig,
-} from '@terascope/job-components';
+import { ConvictSchema, ValidatedJobConfig } from '@terascope/job-components';
 import { S3ExportConfig } from './interfaces';
-import { fileReaderSchema, compareConfig } from '../__lib/common-schema';
+import { opSchema } from '../__lib/common-schema';
 import { DEFAULT_API_NAME } from '../s3_sender_api/interfaces';
-
-const clonedSchema = cloneDeep(fileReaderSchema) as AnyObject;
-
-clonedSchema.api_name = {
-    doc: 'name of api to be used by s3_exporter',
-    default: DEFAULT_API_NAME,
-    format: (val: unknown): void => {
-        if (!isString(val)) throw new Error(`Invalid parameter api_name, it must be of type string, was given ${getTypeOf(val)}`);
-        if (!val.includes(DEFAULT_API_NAME)) throw new Error(`Invalid parameter api_name, it must be an ${DEFAULT_API_NAME}`);
-    }
-};
-
-export const schema = clonedSchema;
 
 export default class Schema extends ConvictSchema<S3ExportConfig> {
     validateJob(job: ValidatedJobConfig): void {
-        const opConfig = getOpConfig(job, 's3_exporter') as S3ExportConfig | undefined;
-        if (isNil(opConfig)) throw new Error('Could not find opConfig for operation s3_exporter');
-        const { api_name, ...apiConfig } = opConfig;
-        if (!Array.isArray(job.apis)) job.apis = [];
-        const S3SenderAPI = job.apis.find((jobApi) => jobApi._name === api_name);
+        let opIndex = 0;
 
-        if (isNil(S3SenderAPI)) {
-            if (isNil(opConfig.path)) throw new Error(`Invalid parameter path, must be of type string, got ${getTypeOf(opConfig.path)}`);
+        const opConfig = job.operations.find((op, ind) => {
+            if (op._op === 's3_exporter') {
+                opIndex = ind;
+                return op;
+            }
+            return false;
+        });
 
-            job.apis.push({
-                _name: DEFAULT_API_NAME,
-                ...apiConfig
-            });
-        } else {
-            compareConfig(opConfig, S3SenderAPI);
-        }
+        if (opConfig == null) throw new Error('Could not find s3_exporter operation in jobConfig');
+
+        const {
+            api_name, ...newConfig
+        } = opConfig;
+
+        const apiName = api_name || `${DEFAULT_API_NAME}:${opConfig._op}-${opIndex}`;
+
+        // we set the new apiName back on the opConfig so it can reference the unique name
+        opConfig.api_name = apiName;
+
+        this.ensureAPIFromConfig(apiName, job, newConfig);
     }
 
     build(): Record<string, any> {
-        return clonedSchema;
+        return opSchema;
     }
 }

--- a/asset/src/s3_reader/schema.ts
+++ b/asset/src/s3_reader/schema.ts
@@ -1,53 +1,35 @@
-import {
-    ConvictSchema,
-    ValidatedJobConfig,
-    getOpConfig,
-    isNil,
-    cloneDeep,
-    AnyObject,
-    isString,
-    getTypeOf,
-    isEmpty,
-} from '@terascope/job-components';
+import { ConvictSchema, ValidatedJobConfig } from '@terascope/job-components';
 import { S3ReaderConfig } from './interfaces';
-import { fileReaderSchema, compareConfig } from '../__lib/common-schema';
+import { opSchema } from '../__lib/common-schema';
 import { DEFAULT_API_NAME } from '../s3_reader_api/interfaces';
-
-const clonedSchema = cloneDeep(fileReaderSchema) as AnyObject;
-
-clonedSchema.api_name = {
-    doc: 'name of api to be used by s3_reader',
-    default: DEFAULT_API_NAME,
-    format: (val: unknown): void => {
-        if (!isString(val)) throw new Error(`Invalid parameter api_name, it must be of type string, was given ${getTypeOf(val)}`);
-        if (!val.includes(DEFAULT_API_NAME)) throw new Error(`Invalid parameter api_name, it must be an ${DEFAULT_API_NAME}`);
-    }
-};
-
-export const schema = clonedSchema;
 
 export default class Schema extends ConvictSchema<S3ReaderConfig> {
     validateJob(job: ValidatedJobConfig): void {
-        const opConfig = getOpConfig(job, 's3_reader') as S3ReaderConfig | undefined;
-        if (isNil(opConfig)) throw new Error('Could not find opConfig for operation s3_reader');
-        const { api_name, ...apiConfig } = opConfig;
-        if (!Array.isArray(job.apis)) job.apis = [];
-        const S3ReaderAPI = job.apis.find((jobApi) => jobApi._name === api_name);
+        let opIndex = 0;
 
-        if (isNil(S3ReaderAPI)) {
-            if (isNil(opConfig.path)) throw new Error(`Invalid parameter path, must be of type string, got ${getTypeOf(opConfig.path)}`);
+        const opConfig = job.operations.find((op, ind) => {
+            if (op._op === 's3_reader') {
+                opIndex = ind;
+                return op;
+            }
+            return false;
+        });
 
-            job.apis.push({
-                _name: DEFAULT_API_NAME,
-                ...apiConfig
-            });
-        } else {
-            if (!isEmpty(opConfig.extra_args)) throw new Error('If api is specified on this operation, the parameter extra_args must not be specified in the opConfig');
-            compareConfig(opConfig, S3ReaderAPI);
-        }
+        if (opConfig == null) throw new Error('Could not find s3_reader operation in jobConfig');
+
+        const {
+            api_name, ...newConfig
+        } = opConfig;
+
+        const apiName = api_name || `${DEFAULT_API_NAME}:${opConfig._op}-${opIndex}`;
+
+        // we set the new apiName back on the opConfig so it can reference the unique name
+        opConfig.api_name = apiName;
+
+        this.ensureAPIFromConfig(apiName, job, newConfig);
     }
 
     build(): Record<string, any> {
-        return clonedSchema;
+        return opSchema;
     }
 }

--- a/asset/src/s3_reader/slicer.ts
+++ b/asset/src/s3_reader/slicer.ts
@@ -38,7 +38,7 @@ export default class S3Slicer extends Slicer<S3ReaderConfig> {
             path
         };
 
-        if (this.opConfig.compression !== 'none') config.file_per_slice = true;
+        if (apiConfig.compression !== 'none') config.file_per_slice = true;
 
         this.slicer = await api.makeS3Slicer(config);
     }

--- a/asset/src/s3_reader_api/schema.ts
+++ b/asset/src/s3_reader_api/schema.ts
@@ -1,14 +1,9 @@
-import { ConvictSchema, cloneDeep } from '@terascope/job-components';
-import { schema } from '../s3_reader/schema';
+import { ConvictSchema } from '@terascope/job-components';
+import { fileReaderSchema } from '../__lib/common-schema';
 import { S3ReaderAPIConfig } from './interfaces';
-
-const { api_name, ...newSchema } = schema;
-
-const apiSchema = cloneDeep(newSchema);
-apiSchema.path.format = 'required_String';
 
 export default class Schema extends ConvictSchema<S3ReaderAPIConfig> {
     build(): Record<string, any> {
-        return apiSchema;
+        return fileReaderSchema;
     }
 }

--- a/asset/src/s3_sender_api/schema.ts
+++ b/asset/src/s3_sender_api/schema.ts
@@ -1,14 +1,9 @@
-import { ConvictSchema, cloneDeep } from '@terascope/job-components';
+import { ConvictSchema } from '@terascope/job-components';
 import { S3ExporterAPIConfig } from './interfaces';
-import { schema } from '../s3_exporter/schema';
-
-const { api_name, ...newSchema } = schema;
-
-const apiSchema = cloneDeep(newSchema);
-apiSchema.path.format = 'required_String';
+import { fileReaderSchema } from '../__lib/common-schema';
 
 export default class Schema extends ConvictSchema<S3ExporterAPIConfig> {
     build(): Record<string, any> {
-        return apiSchema;
+        return fileReaderSchema;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-assets-bundle",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Teraslice processors for working with data stored in files on disk",
     "repository": "https://github.com/terascope/file-assets.git",
     "author": "Terascope, LLC <info@terascope.io>",

--- a/test/file_exporter/schema-spec.ts
+++ b/test/file_exporter/schema-spec.ts
@@ -34,7 +34,7 @@ describe('File exporter Schema', () => {
         });
 
         it('should not throw an error if path is specified in apiConfig', async () => {
-            const opConfig = { _op: 'file_exporter' };
+            const opConfig = { _op: 'file_exporter', api_name: 'file_sender_api' };
             const apiConfig = { _name: 'file_sender_api', path: '/chillywilly' };
 
             await expect(makeTest(opConfig, apiConfig)).toResolve();
@@ -52,7 +52,8 @@ describe('File exporter Schema', () => {
         it('should not throw if _dead_letter_action are the same', async () => {
             const opConfig = {
                 _op: 'file_exporter',
-                _dead_letter_action: 'throw'
+                _dead_letter_action: 'throw',
+                api_name: 'file_sender_api'
             };
 
             const apiConfig = {
@@ -67,7 +68,8 @@ describe('File exporter Schema', () => {
         it('should throw if opConfig _dead_letter_action is not a default value while apiConfig _dead_letter_action is set', async () => {
             const opConfig = {
                 _op: 'file_exporter',
-                _dead_letter_action: 'none'
+                _dead_letter_action: 'none',
+                api_name: 'file_sender_api'
             };
 
             const apiConfig = {
@@ -82,7 +84,8 @@ describe('File exporter Schema', () => {
         it('should not throw if _encoding are the same', async () => {
             const opConfig = {
                 _op: 'file_exporter',
-                _encoding: DataEncoding.JSON
+                _encoding: DataEncoding.JSON,
+                api_name: 'file_sender_api'
             };
 
             const apiConfig = {
@@ -97,7 +100,8 @@ describe('File exporter Schema', () => {
         it('should throw if opConfig _encoding is not a default value while apiConfig _encoding is set', async () => {
             const opConfig = {
                 _op: 'file_exporter',
-                _encoding: DataEncoding.RAW
+                _encoding: DataEncoding.RAW,
+                api_name: 'file_sender_api'
             };
 
             const apiConfig = {

--- a/test/file_reader/schema-spec.ts
+++ b/test/file_reader/schema-spec.ts
@@ -39,22 +39,22 @@ describe('File Reader Schema', () => {
         });
 
         it('should not throw an error if no path is specified if apiConfig is set', async () => {
-            const opConfig = { _op: 'file_reader' };
+            const opConfig = { _op: 'file_reader', api_name: 'file_reader_api' };
             const apiConfig = { _name: 'file_reader_api', path: 'some/path' };
 
             await expect(makeTest(opConfig, apiConfig)).toResolve();
         });
 
-        it('should throw is path is specified and api is specified', async () => {
-            const opConfig = { _op: 'file_reader', path: 'some/path' };
+        it('should throw is path is specified and different than', async () => {
+            const opConfig = { _op: 'file_reader', path: 'some/other', api_name: 'file_reader_api' };
             const apiConfig = { _name: 'file_reader_api', path: 'some/path' };
 
             await expect(makeTest(opConfig, apiConfig)).toReject();
         });
 
-        it('should throw is extra_args is specified and api is specified', async () => {
-            const opConfig = { _op: 'file_reader', extra_args: { some: 'stuff' } };
-            const apiConfig = { _name: 'file_reader_api', path: 'some/path' };
+        it('should throw is extra_args is specified and different from', async () => {
+            const opConfig = { _op: 'file_reader', extra_args: { some: 'stuff' }, api_name: 'file_reader_api' };
+            const apiConfig = { _name: 'file_reader_api', path: 'some/path', extra_args: { some: 'other' } };
 
             await expect(makeTest(opConfig, apiConfig)).toReject();
         });
@@ -62,7 +62,8 @@ describe('File Reader Schema', () => {
         it('should not throw if _dead_letter_action are the same', async () => {
             const opConfig = {
                 _op: 'file_reader',
-                _dead_letter_action: 'throw'
+                _dead_letter_action: 'throw',
+                api_name: 'file_reader_api'
             };
 
             const apiConfig = {
@@ -77,7 +78,8 @@ describe('File Reader Schema', () => {
         it('should throw if opConfig _dead_letter_action is not a default value while apiConfig _dead_letter_action is set', async () => {
             const opConfig = {
                 _op: 'file_reader',
-                _dead_letter_action: 'none'
+                _dead_letter_action: 'none',
+                api_name: 'file_reader_api'
             };
 
             const apiConfig = {
@@ -92,7 +94,8 @@ describe('File Reader Schema', () => {
         it('should not throw if _encoding are the same', async () => {
             const opConfig = {
                 _op: 'file_reader',
-                _encoding: DataEncoding.JSON
+                _encoding: DataEncoding.JSON,
+                api_name: 'file_reader_api'
             };
 
             const apiConfig = {
@@ -107,7 +110,8 @@ describe('File Reader Schema', () => {
         it('should throw if opConfig _encoding is not a default value while apiConfig _encoding is set', async () => {
             const opConfig = {
                 _op: 'file_reader',
-                _encoding: DataEncoding.RAW
+                _encoding: DataEncoding.RAW,
+                api_name: 'file_reader_api'
             };
 
             const apiConfig = {

--- a/test/file_reader_api/api-spec.ts
+++ b/test/file_reader_api/api-spec.ts
@@ -29,7 +29,7 @@ describe('File Reader API', () => {
 
         await harness.initialize();
 
-        return harness.getAPI<FileReaderFactoryAPI>('file_reader_api');
+        return harness.getAPI<FileReaderFactoryAPI>('file_reader_api:file_reader-0');
     }
 
     afterEach(async () => {

--- a/test/file_sender_api/api-spec.ts
+++ b/test/file_sender_api/api-spec.ts
@@ -21,7 +21,7 @@ describe('File Sender API', () => {
 
         workerId = harness.context.cluster.worker.id;
 
-        return harness.getAPI<FileSenderFactoryAPI>('file_sender_api');
+        return harness.getAPI<FileSenderFactoryAPI>('file_sender_api:file_exporter-1');
     }
 
     beforeEach(() => {

--- a/test/s3_exporter/schema-spec.ts
+++ b/test/s3_exporter/schema-spec.ts
@@ -72,8 +72,8 @@ describe('S3 exporter Schema', () => {
             await expect(makeTest(opConfig)).toResolve();
         });
 
-        it('should not throw path is given in api', async () => {
-            const opConfig = {};
+        it('should not throw if path is given in api', async () => {
+            const opConfig = { api_name: 's3_sender_api' };
             const apiConfig = { _name: 's3_sender_api', path: 'chillywilly' };
 
             await expect(makeTest(opConfig, apiConfig)).toResolve();
@@ -82,7 +82,8 @@ describe('S3 exporter Schema', () => {
         it('should not throw if _dead_letter_action are the same', async () => {
             const opConfig = {
                 _op: 's3_exporter',
-                _dead_letter_action: 'throw'
+                _dead_letter_action: 'throw',
+                api_name: 's3_sender_api'
             };
 
             const apiConfig = {
@@ -97,7 +98,8 @@ describe('S3 exporter Schema', () => {
         it('should throw if opConfig _dead_letter_action is not a default value while apiConfig _dead_letter_action is set', async () => {
             const opConfig = {
                 _op: 's3_exporter',
-                _dead_letter_action: 'none'
+                _dead_letter_action: 'none',
+                api_name: 's3_sender_api'
             };
 
             const apiConfig = {
@@ -112,7 +114,8 @@ describe('S3 exporter Schema', () => {
         it('should not throw if _encoding are the same', async () => {
             const opConfig = {
                 _op: 's3_exporter',
-                _encoding: DataEncoding.JSON
+                _encoding: DataEncoding.JSON,
+                api_name: 's3_sender_api'
             };
 
             const apiConfig = {
@@ -127,7 +130,8 @@ describe('S3 exporter Schema', () => {
         it('should throw if opConfig _encoding is not a default value while apiConfig _encoding is set', async () => {
             const opConfig = {
                 _op: 's3_exporter',
-                _encoding: DataEncoding.RAW
+                _encoding: DataEncoding.RAW,
+                api_name: 's3_sender_api'
             };
 
             const apiConfig = {

--- a/test/s3_reader/schema-spec.ts
+++ b/test/s3_reader/schema-spec.ts
@@ -65,7 +65,7 @@ describe('S3 Reader Schema', () => {
         });
 
         it('should not throw path is given in api', async () => {
-            const opConfig = {};
+            const opConfig = { api_name: 's3_reader_api' };
             const apiConfig = { _name: 's3_reader_api', path: 'chillywilly' };
 
             await expect(makeTest(opConfig, apiConfig)).toResolve();
@@ -74,7 +74,8 @@ describe('S3 Reader Schema', () => {
         it('should not throw if _dead_letter_action are the same', async () => {
             const opConfig = {
                 _op: 's3_reader',
-                _dead_letter_action: 'throw'
+                _dead_letter_action: 'throw',
+                api_name: 's3_reader_api'
             };
 
             const apiConfig = {
@@ -89,7 +90,8 @@ describe('S3 Reader Schema', () => {
         it('should throw if opConfig _dead_letter_action is not a default value while apiConfig _dead_letter_action is set', async () => {
             const opConfig = {
                 _op: 's3_reader',
-                _dead_letter_action: 'none'
+                _dead_letter_action: 'none',
+                api_name: 's3_reader_api'
             };
 
             const apiConfig = {
@@ -104,7 +106,8 @@ describe('S3 Reader Schema', () => {
         it('should not throw if _encoding are the same', async () => {
             const opConfig = {
                 _op: 's3_reader',
-                _encoding: DataEncoding.JSON
+                _encoding: DataEncoding.JSON,
+                api_name: 's3_reader_api'
             };
 
             const apiConfig = {
@@ -119,7 +122,8 @@ describe('S3 Reader Schema', () => {
         it('should throw if opConfig _encoding is not a default value while apiConfig _encoding is set', async () => {
             const opConfig = {
                 _op: 's3_reader',
-                _encoding: DataEncoding.RAW
+                _encoding: DataEncoding.RAW,
+                api_name: 's3_reader_api'
             };
 
             const apiConfig = {

--- a/test/s3_reader_api/api-spec.ts
+++ b/test/s3_reader_api/api-spec.ts
@@ -73,7 +73,7 @@ describe('S3 API Reader', () => {
 
         await harness.initialize();
 
-        return harness.getAPI<S3ReaderFactoryAPI>('s3_reader_api');
+        return harness.getAPI<S3ReaderFactoryAPI>('s3_reader_api:s3_reader-0');
     }
 
     afterEach(async () => {

--- a/test/s3_sender_api/api-spec.ts
+++ b/test/s3_sender_api/api-spec.ts
@@ -57,7 +57,7 @@ describe('S3 sender api', () => {
 
         workerId = harness.context.cluster.worker.id;
 
-        return harness.getAPI<S3SenderFactoryAPI>('s3_sender_api');
+        return harness.getAPI<S3SenderFactoryAPI>('s3_sender_api:s3_exporter-1');
     }
 
     beforeAll(async () => {


### PR DESCRIPTION
- migrate schema validations to their respective apis to prevent double validations clashes
- made sure operations use the fully validated apiConfig instead of opConfig