### PR TITLE
2.1.8 - Fix iterator support on sender

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "2.1.7",
+    "version": "2.1.8",
     "description": "A set of processors for working with files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file",
-    "version": "2.1.7",
+    "version": "2.1.8",
     "description": "A set of processors for working with files",
     "private": true,
     "workspaces": {

--- a/asset/package.json
+++ b/asset/package.json
@@ -14,7 +14,7 @@
         "build:watch": "yarn build --watch"
     },
     "dependencies": {
-        "@terascope/file-asset-apis": "^0.5.0",
+        "@terascope/file-asset-apis": "^0.5.1",
         "@terascope/job-components": "^0.53.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-assets-bundle",
-    "version": "2.1.7",
+    "version": "2.1.8",
     "description": "A set of processors for working with files",
     "repository": "https://github.com/terascope/file-assets.git",
     "author": "Terascope, LLC <info@terascope.io>",
@@ -27,7 +27,7 @@
     "dependencies": {},
     "devDependencies": {
         "@terascope/eslint-config": "^0.6.0",
-        "@terascope/file-asset-apis": "^0.5.0",
+        "@terascope/file-asset-apis": "^0.5.1",
         "@terascope/job-components": "^0.53.0",
         "@types/fs-extra": "^9.0.12",
         "@types/jest": "^27.0.1",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/file-asset-apis",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "file reader and sender apis",
     "publishConfig": {
         "access": "public"

--- a/packages/file-asset-apis/src/base/ChunkGenerator.ts
+++ b/packages/file-asset-apis/src/base/ChunkGenerator.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isTest } from '@terascope/utils';
+import { isTest } from '@terascope/utils';
 import { Compressor } from './Compressor';
 import { Formatter } from './Formatter';
 import { Format, Compression, SendRecords } from '../interfaces';
@@ -58,7 +58,7 @@ export class ChunkGenerator {
     }
 
     [Symbol.asyncIterator](): AsyncIterableIterator<Chunk> {
-        if (isEmpty(this.slice)) {
+        if (Array.isArray(this.slice) && this.slice.length === 0) {
             return this._emptyIterator();
         }
         if (this.isRowOptimized()) {


### PR DESCRIPTION
The support for iterators was broken with the use of `isEmpty`