### PR TITLE
Terafoundation async api creation

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "2.2.2",
+    "version": "2.4.0",
     "description": "A set of processors for working with files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -14,7 +14,7 @@
         "build:watch": "yarn build --watch"
     },
     "dependencies": {
-        "@terascope/file-asset-apis": "^0.7.0",
+        "@terascope/file-asset-apis": "^0.7.1",
         "@terascope/job-components": "^0.58.5",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.1.1",

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "description": "A set of processors for working with files",
     "private": true,
     "workspaces": {

--- a/asset/src/s3_reader_api/api.ts
+++ b/asset/src/s3_reader_api/api.ts
@@ -18,11 +18,12 @@ export default class S3ReaderAPI extends APIFactory<S3TerasliceAPI, S3ReaderAPIC
         _name: string, overrideConfigs: Partial<S3ReaderAPIConfig>
     ):Promise<{ client: S3TerasliceAPI, config: S3ReaderAPIConfig }> {
         const config = this.validateConfig(Object.assign({}, this.apiConfig, overrideConfigs));
-        const s3Client = this.context.foundation.getConnection({
+
+        const { client: s3Client } = await this.context.apis.foundation.createClient({
             endpoint: config.connection,
             type: 's3',
             cached: true
-        }).client;
+        });
 
         const tryFn = this.tryRecord.bind(this);
         const rejectFn = this.rejectRecord.bind(this);

--- a/asset/src/s3_sender_api/api.ts
+++ b/asset/src/s3_sender_api/api.ts
@@ -28,11 +28,11 @@ export default class S3SenderAPI extends APIFactory<S3Sender, S3ExporterAPIConfi
             config.dynamic_routing = true;
         }
 
-        const s3Client = this.context.foundation.getConnection({
+        const { client: s3Client } = await this.context.apis.foundation.createClient({
             endpoint: config.connection,
             type: 's3',
             cached: true
-        }).client;
+        });
 
         const client = new S3Sender(s3Client, config, this.logger);
 

--- a/docs/s3_exporter.md
+++ b/docs/s3_exporter.md
@@ -4,6 +4,8 @@ The `s3_exporter` is a processor that will export data to S3. This exporter will
 
 For this processor to run, a path is required in the configuration. The base bucket must of the path must already exists in S3.
 
+If you are using the asset version >= 2.4.0, it should be used on >= teraslice v84.0
+
 ## Usage
 
 ### Write ldjson to file and restrict fields

--- a/docs/s3_exporter.md
+++ b/docs/s3_exporter.md
@@ -4,7 +4,7 @@ The `s3_exporter` is a processor that will export data to S3. This exporter will
 
 For this processor to run, a path is required in the configuration. The base bucket must of the path must already exists in S3.
 
-If you are using the asset version >= 2.4.0, it should be used on >= teraslice v84.0
+If you are using the asset version >= 2.4.0, it should be used on teraslice >= v84.0
 
 ## Usage
 

--- a/docs/s3_reader.md
+++ b/docs/s3_reader.md
@@ -6,6 +6,8 @@ For this processor to run, a path is required in the configuration. All intermed
 
 This reader currently only works in `once` jobs.
 
+If you are using the asset version >= 2.4.0, it should be used on >= teraslice v84.0
+
 ## Usage
 
 ### Read ldjson from a file

--- a/docs/s3_reader.md
+++ b/docs/s3_reader.md
@@ -6,7 +6,7 @@ For this processor to run, a path is required in the configuration. All intermed
 
 This reader currently only works in `once` jobs.
 
-If you are using the asset version >= 2.4.0, it should be used on >= teraslice v84.0
+If you are using the asset version >= 2.4.0, it should be used on teraslice >= v84.0
 
 ## Usage
 

--- a/docs/s3_reader_api.md
+++ b/docs/s3_reader_api.md
@@ -4,6 +4,8 @@ This is a [teraslice api](https://terascope.github.io/teraslice/docs/jobs/config
 
 The `s3_reader_api` will provide an [api factory](https://terascope.github.io/teraslice/docs/packages/job-components/api/classes/apifactory), which is a singleton that can create, cache and manage multiple file sender apis that can be accessed in any operation through the `getAPI` method on the operation.
 
+If you are using the asset version >= 2.4.0, it should be used on >= teraslice v84.0
+
 ## Usage
 
 ### Example Processor using a s3 reader api

--- a/docs/s3_reader_api.md
+++ b/docs/s3_reader_api.md
@@ -4,7 +4,7 @@ This is a [teraslice api](https://terascope.github.io/teraslice/docs/jobs/config
 
 The `s3_reader_api` will provide an [api factory](https://terascope.github.io/teraslice/docs/packages/job-components/api/classes/apifactory), which is a singleton that can create, cache and manage multiple file sender apis that can be accessed in any operation through the `getAPI` method on the operation.
 
-If you are using the asset version >= 2.4.0, it should be used on >= teraslice v84.0
+If you are using the asset version >= 2.4.0, it should be used on teraslice >= v84.0
 
 ## Usage
 

--- a/docs/s3_sender_api.md
+++ b/docs/s3_sender_api.md
@@ -6,7 +6,7 @@ This is a [Factory API](https://terascope.github.io/teraslice/docs/packages/job-
 
 This api is the core of the [s3_exporter](./s3_exporter.md). This contains all the same behavior, functionality and configuration of that exporter
 
-If you are using the asset version >= 2.4.0, it should be used on >= teraslice v84.0
+If you are using the asset version >= 2.4.0, it should be used on teraslice >= v84.0
 
 ## Usage
 

--- a/docs/s3_sender_api.md
+++ b/docs/s3_sender_api.md
@@ -6,6 +6,8 @@ This is a [Factory API](https://terascope.github.io/teraslice/docs/packages/job-
 
 This api is the core of the [s3_exporter](./s3_exporter.md). This contains all the same behavior, functionality and configuration of that exporter
 
+If you are using the asset version >= 2.4.0, it should be used on >= teraslice v84.0
+
 ## Usage
 
 ### Example Processor using a s3 sender api

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-assets-bundle",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "description": "A set of processors for working with files",
     "repository": "https://github.com/terascope/file-assets.git",
     "author": "Terascope, LLC <info@terascope.io>",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {},
     "devDependencies": {
         "@terascope/eslint-config": "^0.7.1",
-        "@terascope/file-asset-apis": "^0.7.0",
+        "@terascope/file-asset-apis": "^0.7.1",
         "@terascope/job-components": "^0.58.5",
         "@terascope/scripts": "^0.50.7",
         "@types/fs-extra": "^11.0.1",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/file-asset-apis",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "file reader and sender apis",
     "publishConfig": {
         "access": "public"

--- a/packages/file-asset-apis/src/s3/createS3Client.ts
+++ b/packages/file-asset-apis/src/s3/createS3Client.ts
@@ -18,8 +18,15 @@ export async function createS3Client(
     config: S3ClientConfig,
     logger = debugLogger('s3-client')
 ): Promise<S3Client> {
-    config.logger = logger;
     logger.info(`Using S3 endpoint: ${config.endpoint}`);
+
+    // The aws v3 client logs every request and its metadata, it is to intrusive
+    // should only be used in trace mode otherwise it will log the body request
+    // which has heavy performance implications
+    if (logger.level() === 10) {
+        config.logger = logger;
+    }
+
     // pull certLocation from env
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-registering-certs.html
     // Instead of updating the client, we can just update the config before creating the client


### PR DESCRIPTION
- update logging to only be used in trace mode so it does not log body request
- update asset version
- migrate internal api usage to use new client from terafoundation
-  MUST BE USED ON >= `v84.0` of teraslice