### PR TITLE
bundled bump update

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "^0.10.1",
-        "@terascope/job-components": "^0.59.0",
+        "@terascope/job-components": "^0.64.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.1.1",
         "json2csv": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "devDependencies": {
         "@terascope/eslint-config": "^0.7.1",
         "@terascope/file-asset-apis": "^0.10.1",
-        "@terascope/job-components": "^0.59.0",
-        "@terascope/scripts": "0.58.0",
+        "@terascope/job-components": "^0.64.0",
+        "@terascope/scripts": "0.59.0",
         "@types/fs-extra": "^11.0.2",
         "@types/jest": "^29.5.5",
         "@types/json2csv": "^5.0.3",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.409.0",
         "@aws-sdk/node-http-handler": "^3.374.0",
-        "@terascope/utils": "^0.46.0",
+        "@terascope/utils": "^0.51.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.1.1",
         "json2csv": "5.0.7",
@@ -30,7 +30,7 @@
         "node-gzip": "^1.1.2"
     },
     "devDependencies": {
-        "@terascope/scripts": "^0.58.0",
+        "@terascope/scripts": "^0.59.0",
         "@types/jest": "^29.5.5",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,24 +1763,24 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.59.0":
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.59.0.tgz#f09b1c81f388beee822064a67427bc259a534b47"
-  integrity sha512-0bfLAzlQoWZEtKiymIhp9duEM8JGKWF7LXyoU67N1nQehs8PJ/quWuBYfCEcr9Oa0d4ba458u5gRTBefxRRdeg==
+"@terascope/job-components@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.64.0.tgz#667522ffec485ca71e4037b902a1c0a0924c2243"
+  integrity sha512-ScxcgNt+kvsrlOm8FhnmqpAvj5ozowiuDMenrk1zvBytkwc7gl20WQqWDQs6ilLSkBB3I9T4YT4laGwQbtoYNg==
   dependencies:
-    "@terascope/utils" "^0.46.0"
+    "@terascope/utils" "^0.51.0"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
     datemath-parser "^1.0.6"
     uuid "^9.0.0"
 
-"@terascope/scripts@0.58.0", "@terascope/scripts@^0.58.0":
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.58.0.tgz#cd6d941ea8f62afa0ecc0e07fe0471fbf48e4da8"
-  integrity sha512-TM4iv0vafBVSSsu35lccfjIzm7sfqG2NaLzFWprFV63SvAdkBiktvHWrIaGXPucKIjuA3wdOVzf/qWwrgN/VGA==
+"@terascope/scripts@0.59.0", "@terascope/scripts@^0.59.0":
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.59.0.tgz#bec8491358e1e4365682041bf98fb43a51dd192c"
+  integrity sha512-NRb3TYFleFAhXvb0kn3rrZIvl3WupFJn/X4IV+xtrmI3IgL/oCLmI+bjru6W5Wg1LwuyhJ4qbcKGfQZkKzK9gQ==
   dependencies:
-    "@terascope/utils" "^0.50.0"
+    "@terascope/utils" "^0.51.0"
     codecov "^3.8.3"
     execa "^5.1.0"
     fs-extra "^10.1.0"
@@ -1814,51 +1814,10 @@
   resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.11.2.tgz#8439b04ba4c5d8357d00a7e20a831f4864ae4c81"
   integrity sha512-oWrKZYm5HsZc2bCxirPnnYD6yu5wW74W7OTKD7Vm38KI/8TcfZPlr/U+gBwocQGVJrBM9jg0+jcjaxudLjfXiw==
 
-"@terascope/utils@^0.46.0":
-  version "0.46.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.46.0.tgz#949ecbad7a1f678ad84861a6cde45d812f29dade"
-  integrity sha512-shgYj0I57nZ2sT0v5zoQwD+KnHSFXn1quYrGGzH2RAdl2UFz9fibfkVC4nM+bmkT9ptuzEBjyqEXnD/L027jdQ==
-  dependencies:
-    "@terascope/types" "^0.11.2"
-    "@turf/bbox" "^6.4.0"
-    "@turf/bbox-polygon" "^6.4.0"
-    "@turf/boolean-contains" "^6.4.0"
-    "@turf/boolean-disjoint" "^6.4.0"
-    "@turf/boolean-equal" "^6.4.0"
-    "@turf/boolean-intersects" "^6.4.0"
-    "@turf/boolean-point-in-polygon" "^6.4.0"
-    "@turf/boolean-within" "^6.4.0"
-    "@turf/circle" "^6.4.0"
-    "@turf/helpers" "^6.2.0"
-    "@turf/invariant" "^6.2.0"
-    "@turf/line-to-polygon" "^6.4.0"
-    "@types/lodash" "^4.14.195"
-    "@types/validator" "^13.7.17"
-    awesome-phonenumber "^2.70.0"
-    date-fns "^2.30.0"
-    date-fns-tz "^1.3.7"
-    datemath-parser "^1.0.6"
-    debug "^4.3.4"
-    geo-tz "^7.0.7"
-    ip-bigint "^3.0.3"
-    ip6addr "^0.2.5"
-    ipaddr.js "^2.0.1"
-    is-cidr "^4.0.2"
-    is-ip "^3.1.0"
-    is-plain-object "^5.0.0"
-    js-string-escape "^1.0.1"
-    kind-of "^6.0.3"
-    latlon-geohash "^1.1.0"
-    lodash "^4.17.21"
-    mnemonist "^0.39.5"
-    p-map "^4.0.0"
-    shallow-clone "^3.0.1"
-    validator "^13.9.0"
-
-"@terascope/utils@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.50.0.tgz#dd45b4ff03632756a0a135041c02a44e0ae27c7d"
-  integrity sha512-+FqiwTaDso1EqtLmvB7u+YdPnvpcW9CwKbbpGqRramssV4JG+Euw5tJgcwt4sObPv6xSbCzEyUoASARU85jSNg==
+"@terascope/utils@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.51.0.tgz#ff48164dd4e3afa501517fdaac4fa2ac1f4a5323"
+  integrity sha512-PneoBPGLZJvsRU8edQG0IISzNj3aKB1SZc2wPJW2jn30cGEyU+lltebDYtS2A204c98duslRD4u7npb6byecAw==
   dependencies:
     "@terascope/types" "^0.11.2"
     "@turf/bbox" "^6.4.0"


### PR DESCRIPTION
I have updated all of the following ```packages``` at the same time because it is required to do so without a ```type``` error.

- ```@terascope/job-components@0.59.0 ---> 0.64.0```
- ```@terascope/utils@0.46.0 ---> 0.51.0```
- ```@terascope/scripts@0.58.0 ---> 0.59.0```