### PR TITLE
Bundled dependency update Jan 8th 2024

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "^0.10.2",
-        "@terascope/job-components": "^0.65.1",
+        "@terascope/job-components": "^0.66.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.2.0",
         "json2csv": "5.0.7",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.485.0",
         "@smithy/node-http-handler": "^2.2.1",
-        "@terascope/utils": "^0.52.1",
+        "@terascope/utils": "^0.53.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.2.0",
         "json2csv": "5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,6 +1872,18 @@
     datemath-parser "^1.0.6"
     uuid "^9.0.0"
 
+"@terascope/job-components@^0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.66.0.tgz#e4aec4f325c5373315ea81df9939b8cdc5628dbd"
+  integrity sha512-76AfRqRQomKKBvkxcT7lJhq0PWPMQaegi44bBPvNmRTtigEHzTo0n0nluQ5r7CUUQI3rOLOzr42Xy+2pxwRpMQ==
+  dependencies:
+    "@terascope/utils" "^0.53.0"
+    convict "^6.2.4"
+    convict-format-with-moment "^6.2.0"
+    convict-format-with-validator "^6.2.0"
+    datemath-parser "^1.0.6"
+    uuid "^9.0.0"
+
 "@terascope/scripts@^0.63.0":
   version "0.63.0"
   resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.63.0.tgz#8d675b23c39abe8e8475a7b11736fb48b6711a4a"
@@ -1916,6 +1928,48 @@
   version "0.52.1"
   resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.52.1.tgz#26eeed6bdbe69cfa20226560456e70a1b8d65024"
   integrity sha512-6XH3bSHdwUznBecLjzoo+yytcwcA6cYIxbipm4LzCCbfCPycKK4j8fKSuXjOaT//DXU7vEFsSzH0o9GeoAPnEA==
+  dependencies:
+    "@terascope/types" "^0.12.1"
+    "@turf/bbox" "^6.4.0"
+    "@turf/bbox-polygon" "^6.4.0"
+    "@turf/boolean-contains" "^6.4.0"
+    "@turf/boolean-disjoint" "^6.4.0"
+    "@turf/boolean-equal" "^6.4.0"
+    "@turf/boolean-intersects" "^6.4.0"
+    "@turf/boolean-point-in-polygon" "^6.4.0"
+    "@turf/boolean-within" "^6.4.0"
+    "@turf/circle" "^6.4.0"
+    "@turf/helpers" "^6.2.0"
+    "@turf/invariant" "^6.2.0"
+    "@turf/line-to-polygon" "^6.4.0"
+    "@types/lodash" "^4.14.195"
+    "@types/validator" "^13.11.7"
+    awesome-phonenumber "^2.70.0"
+    date-fns "^2.30.0"
+    date-fns-tz "^1.3.7"
+    datemath-parser "^1.0.6"
+    debug "^4.3.4"
+    geo-tz "^7.0.7"
+    ip-bigint "^3.0.3"
+    ip-cidr "^3.1.0"
+    ip6addr "^0.2.5"
+    ipaddr.js "^2.0.1"
+    is-cidr "^4.0.2"
+    is-ip "^3.1.0"
+    is-plain-object "^5.0.0"
+    js-string-escape "^1.0.1"
+    kind-of "^6.0.3"
+    latlon-geohash "^1.1.0"
+    lodash "^4.17.21"
+    mnemonist "^0.39.5"
+    p-map "^4.0.0"
+    shallow-clone "^3.0.1"
+    validator "^13.11.0"
+
+"@terascope/utils@^0.53.0":
+  version "0.53.0"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.53.0.tgz#120dddb70ef0be165f4416132a2ac33109208911"
+  integrity sha512-RSwyaaPWcnhGMuC5W0qJ99y0GczPoU9NgH8JjM7+vKYT3i3Wt6CZuxHhHP9Aa8Vs3W+96BLmZwaqX5XSHu0zHw==
   dependencies:
     "@terascope/types" "^0.12.1"
     "@turf/bbox" "^6.4.0"


### PR DESCRIPTION
Updated the following dependencies:

- **@terascope/job-components** `v0.65.1` --> `v0.66.0`
- **@terascope/utils** `v0.52.1` --> `v0.53.0` 