### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@87417c24b289012e5665f4aea5eaad78431dbe31
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@6dfb22a4299550935fb58a16aa544837a43fe38c
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@87417c24b289012e5665f4aea5eaad78431dbe31
+    uses: terascope/workflows/.github/workflows/asset-test.yml@6dfb22a4299550935fb58a16aa544837a43fe38c
     secrets: inherit

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "description": "A set of processors for working with files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -30,7 +30,7 @@
     },
     "devDependencies": {},
     "engines": {
-        "node": ">=16.19.0",
+        "node": ">=18.0.0",
         "yarn": ">=1.22.19"
     },
     "terascope": {}

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file",
     "displayName": "Asset",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": {
@@ -20,7 +20,7 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/file-asset-apis": "^0.11.0",
+        "@terascope/file-asset-apis": "^0.11.1",
         "@terascope/job-components": "^0.66.1",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "typescript": "~5.2.2"
     },
     "engines": {
-        "node": ">=16.19.0",
+        "node": ">=18.0.0",
         "yarn": ">=1.22.19"
     },
     "terascope": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file-assets-bundle",
     "displayName": "File Assets Bundle",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": "https://github.com/terascope/file-assets.git",
@@ -30,7 +30,7 @@
     "dependencies": {},
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/file-asset-apis": "^0.11.0",
+        "@terascope/file-asset-apis": "^0.11.1",
         "@terascope/job-components": "^0.66.1",
         "@terascope/scripts": "^0.70.0",
         "@types/fs-extra": "^11.0.2",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/file-asset-apis",
     "displayName": "File Asset Apis",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "description": "file reader and sender apis",
     "homepage": "https://github.com/terascope/file-assets",
     "repository": "git@github.com:terascope/file-assets.git",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {},
     "engines": {
-        "node": ">=16.19.0",
+        "node": ">=18.0.0",
         "yarn": ">=1.22.19"
     },
     "publishConfig": {


### PR DESCRIPTION
Update minimum node engine version from 16.19.0 to 18.0.0
Update workflows hash - new workflow runs on node 18.19.1 only
Bump asset from 2.8.0 to 2.8.1 
Bump file-asset-apis from 0.11.0 to 0.11.1