### PR TITLE
Update github workflows - pins teraslice-cli version

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@c6ee4b1fb5eac0788f2b7fd607de4f03c54c89aa
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@bb318f6a11fa77b714c16ee3f4c7c02689d5bef9
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@c6ee4b1fb5eac0788f2b7fd607de4f03c54c89aa
+    uses: terascope/workflows/.github/workflows/asset-test.yml@bb318f6a11fa77b714c16ee3f4c7c02689d5bef9
     secrets: inherit


### PR DESCRIPTION
Update github workflows to a version that temporarily pins teraslice-cli to version 0.62.0
