### PR TITLE
Bundled dependency update March 25 2024

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "^0.12.0",
-        "@terascope/job-components": "^0.68.0",
+        "@terascope/job-components": "^0.69.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.2.0",
         "json2csv": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
         "@terascope/file-asset-apis": "^0.12.0",
-        "@terascope/job-components": "^0.68.0",
+        "@terascope/job-components": "^0.69.0",
         "@terascope/scripts": "^0.72.2",
         "@types/fs-extra": "^11.0.2",
         "@types/jest": "^29.5.12",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.535.0",
         "@smithy/node-http-handler": "^2.4.3",
-        "@terascope/utils": "^0.55.0",
+        "@terascope/utils": "^0.56.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.2.0",
         "json2csv": "5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,12 +1885,12 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.68.0":
-  version "0.68.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.68.0.tgz#e49ed8eef145f6f3d83e93e447681b1245f19578"
-  integrity sha512-ACnbW5vZHH4smKy0rtvyKIGA9OBos1Xj4oA0L/Bcnx+J1j/5sdM+4PlzH+mxppr9zgOf5OWCBljrXBmhkaSAog==
+"@terascope/job-components@^0.69.0":
+  version "0.69.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.69.0.tgz#5c5cd8c1cba79c8840b86b2cb50d14dfc8ccd763"
+  integrity sha512-LFLK0LN0VXQN6F/ZoGHfKdaBv+J5l+XD71RMnhZuGiAdJaYWBfnUyxlWbvbUF2Y+3hyXLhl0WvEUeoWdijLv6Q==
   dependencies:
-    "@terascope/utils" "^0.55.0"
+    "@terascope/utils" "^0.56.0"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
@@ -1938,12 +1938,59 @@
   resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.14.0.tgz#eb5ad8a24b0a2d1b4517629fe5cf976f7ebef72c"
   integrity sha512-sX15SWV/AOlVBkcjgHlXMXSoJJHDBNWRMbxqcYxY7IlZq9WegU3SBtsxdD01uYSXvwKTrAInjeG1PA00WN0jtA==
 
+"@terascope/types@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.15.0.tgz#820d6aa9fd76bdedfaad0e5b1cc5b77b5490b8dd"
+  integrity sha512-z5mfmFOXMEjq6S3WZANXBIEeM7FK/XSON+9kR6RX7GNHW/a6qNif9pSIAARQz4420JoYDliccSLJX9v0r6DfKg==
+
 "@terascope/utils@^0.55.0":
   version "0.55.0"
   resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.55.0.tgz#9f3db4632782fae3f043288482449de2f25a7672"
   integrity sha512-KhRpyUh8SW1AUYvPPtbZ4tzqWfejJrnvrGTZEaUAB8j5BfYklnTHU6OoJ1hvgGn43mC48z7/zwxlhPubjqe70g==
   dependencies:
     "@terascope/types" "^0.14.0"
+    "@turf/bbox" "^6.4.0"
+    "@turf/bbox-polygon" "^6.4.0"
+    "@turf/boolean-contains" "^6.4.0"
+    "@turf/boolean-disjoint" "^6.4.0"
+    "@turf/boolean-equal" "^6.4.0"
+    "@turf/boolean-intersects" "^6.4.0"
+    "@turf/boolean-point-in-polygon" "^6.4.0"
+    "@turf/boolean-within" "^6.4.0"
+    "@turf/circle" "^6.4.0"
+    "@turf/helpers" "^6.2.0"
+    "@turf/invariant" "^6.2.0"
+    "@turf/line-to-polygon" "^6.4.0"
+    "@types/lodash" "^4.14.202"
+    "@types/validator" "^13.11.9"
+    awesome-phonenumber "^2.70.0"
+    date-fns "^2.30.0"
+    date-fns-tz "^1.3.7"
+    datemath-parser "^1.0.6"
+    debug "^4.3.4"
+    geo-tz "^7.0.7"
+    ip-bigint "^3.0.3"
+    ip-cidr "^3.1.0"
+    ip6addr "^0.2.5"
+    ipaddr.js "^2.0.1"
+    is-cidr "^4.0.2"
+    is-ip "^3.1.0"
+    is-plain-object "^5.0.0"
+    js-string-escape "^1.0.1"
+    kind-of "^6.0.3"
+    latlon-geohash "^1.1.0"
+    lodash "^4.17.21"
+    mnemonist "^0.39.8"
+    p-map "^4.0.0"
+    shallow-clone "^3.0.1"
+    validator "^13.11.0"
+
+"@terascope/utils@^0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.56.0.tgz#f325a6074dd140aa7446761a2716cbf32583db94"
+  integrity sha512-AbgBj0qliwtPMlHyL1Kng24dzoznBcfACIV98/5l9DQBDDB9zTHwPtDYAaKlFA3GYynl+7Anlm+ffUXll3M2eA==
+  dependencies:
+    "@terascope/types" "^0.15.0"
     "@turf/bbox" "^6.4.0"
     "@turf/bbox-polygon" "^6.4.0"
     "@turf/boolean-contains" "^6.4.0"


### PR DESCRIPTION
This PR updates the following dependencies:

- @terascope/job-components from `v0.68.0` to `v0.69.0`
- @terascope/utils from `v0.55.0` to `v0.56.0`