### PR TITLE
Fix broken TLS s3 client creation

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "A set of processors for working with files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file",
     "displayName": "Asset",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": {
@@ -20,7 +20,7 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/file-asset-apis": "^0.12.0",
+        "@terascope/file-asset-apis": "^0.12.1",
         "@terascope/job-components": "^0.69.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file-assets-bundle",
     "displayName": "File Assets Bundle",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": "https://github.com/terascope/file-assets.git",
@@ -30,7 +30,7 @@
     "dependencies": {},
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/file-asset-apis": "^0.12.0",
+        "@terascope/file-asset-apis": "^0.12.1",
         "@terascope/job-components": "^0.69.0",
         "@terascope/scripts": "^0.73.0",
         "@types/fs-extra": "^11.0.2",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/file-asset-apis",
     "displayName": "File Asset Apis",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "file reader and sender apis",
     "homepage": "https://github.com/terascope/file-assets",
     "repository": "git@github.com:terascope/file-assets.git",

--- a/packages/file-asset-apis/src/s3/createS3Client.ts
+++ b/packages/file-asset-apis/src/s3/createS3Client.ts
@@ -60,7 +60,7 @@ export async function createS3Client(
     const requestHandlerOptions = {
         ...isNumber(connectionTimeout) && { connectionTimeout },
         ...isNumber(requestTimeout) && { requestTimeout },
-        ...!isEmpty(httpOptions) && new Agent(httpOptions)
+        ...!isEmpty(httpOptions) && { httpsAgent: new Agent(httpOptions) }
     };
 
     if (!isEmpty(requestHandlerOptions)) {


### PR DESCRIPTION
This PR makes the following chnages:

- Fixes a bug that doesn't allow for the creation of an s3 client when `sslEnabled` is `true` in terafoundation
  - This resolves errors that are specific to verifying or finding certificates

Ref #960