### PR TITLE
use caCertificate and globalCaCertificate in createS3Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ terafoundation:
                 accessKeyId: "yourId"
                 secretAccessKey: "yourPassword"
                 forcePathStyle: true
-                sslEnabled: false
+                sslEnabled: true
+                caCertificate: |
+                    -----BEGIN CERTIFICATE-----
+                    MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQs
+                    ...
+                    DXZDjC5Ty3zfDBeWUA==
+                    -----END CERTIFICATE-----
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ The S3 connector configuration, in your Teraslice configuration file, includes t
 | secretAccessKey | S3 secret access key | String | required |
 | region | AWS Region where bucket is located | String | optional, defaults to `us-east-1` |
 | maxRetries | Maximum retry attempts | Number | optional, defaults to `3` |
-| maxRedirects | Maximum redirects allowed | Number | optional, defaults to `10` |
 | sslEnabled | Flag to enable/disable SSL communication | Boolean | optional, defaults to `true` |
-| certLocation | Location of ssl cert | String | Must be provided if `sslEnabled` is true |
+| caCertificate | A string containing a single or multiple ca certificates | String | optional, defaults to ' ' |
+| certLocation | DEPRECATED - use caCertificate. Location of ssl cert | String | optional, defaults to ' ' |
 | forcePathStyle | Whether to force path style URLs for S3 objects | Boolean | optional, defaults to `false` |
 | bucketEndpoint | Whether to use the bucket name as the endpoint for this request | Boolean | optional, defaults to `false` |
 

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "2.9.1",
+    "version": "2.10.0",
     "description": "A set of processors for working with files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file",
     "displayName": "Asset",
-    "version": "2.9.2",
+    "version": "2.10.0",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": {
@@ -20,7 +20,7 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/file-asset-apis": "^0.12.2",
+        "@terascope/file-asset-apis": "^0.13.0",
         "@terascope/job-components": "^0.71.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file-assets-bundle",
     "displayName": "File Assets Bundle",
-    "version": "2.9.2",
+    "version": "2.10.0",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": "https://github.com/terascope/file-assets.git",
@@ -30,7 +30,7 @@
     "dependencies": {},
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/file-asset-apis": "^0.12.2",
+        "@terascope/file-asset-apis": "^0.13.0",
         "@terascope/job-components": "^0.71.0",
         "@terascope/scripts": "^0.75.1",
         "@types/fs-extra": "^11.0.2",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/file-asset-apis",
     "displayName": "File Asset Apis",
-    "version": "0.12.2",
+    "version": "0.13.0",
     "description": "file reader and sender apis",
     "homepage": "https://github.com/terascope/file-assets",
     "repository": "git@github.com:terascope/file-assets.git",

--- a/packages/file-asset-apis/src/s3/createS3Client.ts
+++ b/packages/file-asset-apis/src/s3/createS3Client.ts
@@ -85,28 +85,28 @@ export async function createHttpOptions(
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-registering-certs.html
     // Instead of updating the client, we can just update the config before creating the client
 
-    const allCerts: string[] = [];
-    const defaultCerts = tls.rootCertificates;
+    const terafoundationCerts: string[] = [];
+    const defaultNodeCerts = tls.rootCertificates;
 
     // Deprecated
     if (config.certLocation) {
         const certPathFound = await fs.existsSync(config.certLocation);
         if (certPathFound) {
-            allCerts.push(await fs.readFileSync(config.certLocation, 'ascii'));
+            terafoundationCerts.push(await fs.readFileSync(config.certLocation, 'ascii'));
         } else {
             throw new Error(`No cert path was found in config.certLocation: "${config.certLocation}"`);
         }
     }
 
     if (config.caCertificate) {
-        allCerts.push(config.caCertificate);
+        terafoundationCerts.push(config.caCertificate);
     }
 
     if (config.globalCaCertificate) {
-        allCerts.push(config.globalCaCertificate);
+        terafoundationCerts.push(config.globalCaCertificate);
     }
 
-    allCerts.push(...defaultCerts);
+    const allCerts: string[] = terafoundationCerts.concat(defaultNodeCerts);
 
     return {
         rejectUnauthorized: true,

--- a/packages/file-asset-apis/src/s3/createS3Client.ts
+++ b/packages/file-asset-apis/src/s3/createS3Client.ts
@@ -93,6 +93,8 @@ export async function createHttpOptions(
         const certPathFound = await fs.existsSync(config.certLocation);
         if (certPathFound) {
             allCerts.push(await fs.readFileSync(config.certLocation, 'ascii'));
+        } else {
+            throw new Error(`No cert path was found in config.certLocation: "${config.certLocation}"`);
         }
     }
 

--- a/packages/file-asset-apis/test/__fixtures__/cert/fakeCert.pem
+++ b/packages/file-asset-apis/test/__fixtures__/cert/fakeCert.pem
@@ -1,2 +1,5 @@
-createS3Client-spec just needs to find a file in this directory.
-There is no need to use an actual cert with the tests running currently.
+-----BEGIN CERTIFICATE-----
+MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw
+...
+DXZDjC5Ty3zfDBeWUA==
+-----END CERTIFICATE-----

--- a/packages/file-asset-apis/test/s3/createS3Client-spec.ts
+++ b/packages/file-asset-apis/test/s3/createS3Client-spec.ts
@@ -145,42 +145,34 @@ describe('createS3Client', () => {
     });
 
     describe('createHttpOptions', () => {
-        it('should throw an error if caCertificate, globalCaCertificate, and "/etc/ssl/certs/ca-certificates.crt" are empty', async () => {
-            const startConfig = {
-                endpoint: 'https://127.0.0.1:49000',
-                region: 'us-east-1',
-                sslEnabled: true,
-            };
-
-            await expect(createHttpOptions(startConfig))
-                .rejects.toThrow('No cert was provided by config.globalCaCertificate, config.caCertificate, or in default "/etc/ssl/certs/ca-certificates.crt" location');
-        });
-
-        it('should return an httpOptions with caCertificate copied into array', async () => {
+        it('should return an httpOptions with caCertificate copied into array[0]', async () => {
             const startConfig = {
                 endpoint: 'https://127.0.0.1:49000',
                 region: 'us-east-1',
                 caCertificate: '-----BEGIN CERTIFICATE-----\n'
-                + 'MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw\n'
-                + '...\n'
-                + 'DXZDjC5Ty3zfDBeWUA==\n'
-                + '-----END CERTIFICATE-----',
+                    + 'MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw\n'
+                    + '...\n'
+                    + 'DXZDjC5Ty3zfDBeWUA==\n'
+                    + '-----END CERTIFICATE-----',
             };
 
             const result = await createHttpOptions(startConfig);
             expect(result).toEqual({
                 rejectUnauthorized: true,
-                ca: expect.toContainValue(
+                ca: expect.toBeArray()
+            });
+            if (result.ca) {
+                expect(result.ca[0]).toEqual(
                     '-----BEGIN CERTIFICATE-----\n'
                     + 'MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw\n'
                     + '...\n'
                     + 'DXZDjC5Ty3zfDBeWUA==\n'
                     + '-----END CERTIFICATE-----'
-                )
-            });
+                );
+            }
         });
 
-        it('should return an httpOptions with globalCaCertificate copied into array', async () => {
+        it('should return an httpOptions with globalCaCertificate copied into array[0]', async () => {
             const startConfig = {
                 endpoint: 'https://127.0.0.1:49000',
                 region: 'us-east-1',
@@ -194,17 +186,20 @@ describe('createS3Client', () => {
             const result = await createHttpOptions(startConfig);
             expect(result).toEqual({
                 rejectUnauthorized: true,
-                ca: expect.toContainValue(
+                ca: expect.toBeArray()
+            });
+            if (result.ca) {
+                expect(result.ca[0]).toEqual(
                     '-----BEGIN CERTIFICATE-----\n'
                     + 'MIICUDCCAdoCBDaM1tYwDQYJKoZIhvcNAQEEBQAwgY8xCzAJBgNVBAYTAlVTMRMw\n'
                     + '...\n'
                     + 'iKlsPBRbNdq5cNIuIfPS8emrYMs=\n'
                     + '-----END CERTIFICATE-----'
-                )
-            });
+                );
+            }
         });
 
-        it('should return an httpOptions with multiple certs', async () => {
+        it('should return an httpOptions with multiple certs in right order', async () => {
             const startConfig = {
                 endpoint: 'https://127.0.0.1:49000',
                 region: 'us-east-1',
@@ -223,19 +218,24 @@ describe('createS3Client', () => {
             const result = await createHttpOptions(startConfig);
             expect(result).toEqual({
                 rejectUnauthorized: true,
-                ca: expect.toContainValues([
+                ca: expect.toBeArray()
+            });
+            if (result.ca) {
+                expect(result.ca[0]).toEqual(
                     '-----BEGIN CERTIFICATE-----\n'
                     + 'MIICGTCCAZ+gAwIBAgIQCeCTZaz32ci5PhwLBCou8zAKBggqhkjOPQQDAzBOMQsw\n'
                     + '...\n'
                     + 'DXZDjC5Ty3zfDBeWUA==\n'
-                    + '-----END CERTIFICATE-----',
+                    + '-----END CERTIFICATE-----'
+                );
+                expect(result.ca[1]).toEqual(
                     '-----BEGIN CERTIFICATE-----\n'
                     + 'MIICUDCCAdoCBDaM1tYwDQYJKoZIhvcNAQEEBQAwgY8xCzAJBgNVBAYTAlVTMRMw\n'
                     + '...\n'
                     + 'iKlsPBRbNdq5cNIuIfPS8emrYMs=\n'
                     + '-----END CERTIFICATE-----'
-                ])
-            });
+                );
+            }
         });
     });
 
@@ -244,10 +244,10 @@ describe('createS3Client', () => {
             const httpOptions = {
                 rejectUnauthorized: true,
                 ca: ['-----BEGIN CERTIFICATE-----\n'
-                + 'MIICUDCCAdoCBDaM1tYwDQYJKoZIhvcNAQEEBQAwgY8xCzAJBgNVBAYTAlVTMRMw\n'
-                + '...\n'
-                + 'iKlsPBRbNdq5cNIuIfPS8emrYMs=\n'
-                + '-----END CERTIFICATE-----']
+                    + 'MIICUDCCAdoCBDaM1tYwDQYJKoZIhvcNAQEEBQAwgY8xCzAJBgNVBAYTAlVTMRMw\n'
+                    + '...\n'
+                    + 'iKlsPBRbNdq5cNIuIfPS8emrYMs=\n'
+                    + '-----END CERTIFICATE-----']
             };
 
             const result = createRequestHandlerOptions(httpOptions);
@@ -256,10 +256,10 @@ describe('createS3Client', () => {
                     options: {
                         rejectUnauthorized: true,
                         ca: ['-----BEGIN CERTIFICATE-----\n'
-                        + 'MIICUDCCAdoCBDaM1tYwDQYJKoZIhvcNAQEEBQAwgY8xCzAJBgNVBAYTAlVTMRMw\n'
-                        + '...\n'
-                        + 'iKlsPBRbNdq5cNIuIfPS8emrYMs=\n'
-                        + '-----END CERTIFICATE-----'],
+                            + 'MIICUDCCAdoCBDaM1tYwDQYJKoZIhvcNAQEEBQAwgY8xCzAJBgNVBAYTAlVTMRMw\n'
+                            + '...\n'
+                            + 'iKlsPBRbNdq5cNIuIfPS8emrYMs=\n'
+                            + '-----END CERTIFICATE-----'],
                         noDelay: true,
                         path: null
                     }


### PR DESCRIPTION
Within `createS3Client` the `createHttpOptions` function will create an object of type `httpsAgentOptions` with an array of CA certificates from the following locations:
- S3 connector `caCertificate` field
- terafoundation `global_ca_certificate` field
- nodejs `tls.rootCertificates` array

`etc/ssl/certs/ca-certificates.crt` will no longer be used for default root certificates.