### PR TITLE
Add prom metrics to s3 operations

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "description": "A set of processors for working with files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file",
     "displayName": "Asset",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": {

--- a/asset/src/s3_exporter/processor.ts
+++ b/asset/src/s3_exporter/processor.ts
@@ -16,7 +16,7 @@ export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;
         await this.context.apis.foundation.promMetrics.addGauge(
-            'records_written_from_s3',
+            'records_written_to_s3',
             'Number of records written into s3',
             ['op_config'],
             async function collect() {

--- a/asset/src/s3_exporter/processor.ts
+++ b/asset/src/s3_exporter/processor.ts
@@ -18,7 +18,7 @@ export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
         await this.context.apis.foundation.promMetrics.addGauge(
             'records_written_to_s3',
             'Number of records written into s3',
-            ['op_config'],
+            ['op_name'],
             async function collect() {
                 const labels = {
                     class: 's3_exporter',

--- a/asset/src/s3_exporter/processor.ts
+++ b/asset/src/s3_exporter/processor.ts
@@ -13,7 +13,6 @@ export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
         const apiManager = this.getAPI<S3SenderFactoryAPI>(apiName);
         // this processor does not allow dynamic routing, use routed-sender operation instead
         this.api = await apiManager.create(apiName, { dynamic_routing: false });
-        const { context } = this;
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;
         await this.context.apis.foundation.promMetrics.addGauge(
@@ -23,7 +22,7 @@ export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
             async function collect() {
                 const labels = {
                     class: 'S3Batcher',
-                    ...context.apis.foundation.promMetrics.getDefaultLabels()
+                    ...self.context.apis.foundation.promMetrics.getDefaultLabels()
                 };
                 this.set(labels, self.getTotalProcessedS3Records());
             });

--- a/asset/src/s3_exporter/processor.ts
+++ b/asset/src/s3_exporter/processor.ts
@@ -5,6 +5,7 @@ import { S3SenderFactoryAPI } from '../s3_sender_api/interfaces';
 
 export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
     api!: S3Sender;
+    private s3RecordsProcessed = 0;
 
     async initialize(): Promise<void> {
         await super.initialize();
@@ -12,10 +13,29 @@ export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
         const apiManager = this.getAPI<S3SenderFactoryAPI>(apiName);
         // this processor does not allow dynamic routing, use routed-sender operation instead
         this.api = await apiManager.create(apiName, { dynamic_routing: false });
+        const { context } = this;
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+        await this.context.apis.foundation.promMetrics.addGauge(
+            'records_read_from_s3',
+            'Number of records read from s3',
+            ['class'],
+            async function collect() {
+                const labels = {
+                    class: 'S3Fetcher',
+                    ...context.apis.foundation.promMetrics.getDefaultLabels()
+                };
+                this.set(labels, self.getTotalProcessedS3Records());
+            });
     }
 
     async onBatch(slice: DataEntity[]): Promise<DataEntity[]> {
+        this.s3RecordsProcessed += slice.length;
         await this.api.send(slice);
         return slice;
+    }
+
+    getTotalProcessedS3Records(): number {
+        return this.s3RecordsProcessed;
     }
 }

--- a/asset/src/s3_exporter/processor.ts
+++ b/asset/src/s3_exporter/processor.ts
@@ -21,7 +21,7 @@ export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
             ['op_name'],
             async function collect() {
                 const labels = {
-                    class: 's3_exporter',
+                    op_name: 's3_exporter',
                     ...self.context.apis.foundation.promMetrics.getDefaultLabels()
                 };
                 this.set(labels, self.getTotalWrittenS3Records());

--- a/asset/src/s3_exporter/processor.ts
+++ b/asset/src/s3_exporter/processor.ts
@@ -17,12 +17,12 @@ export default class S3Batcher extends BatchProcessor<S3ExportConfig> {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;
         await this.context.apis.foundation.promMetrics.addGauge(
-            'records_read_from_s3',
-            'Number of records read from s3',
+            'records_processed_from_s3',
+            'Number of records written into s3',
             ['class'],
             async function collect() {
                 const labels = {
-                    class: 'S3Fetcher',
+                    class: 'S3Batcher',
                     ...context.apis.foundation.promMetrics.getDefaultLabels()
                 };
                 this.set(labels, self.getTotalProcessedS3Records());

--- a/asset/src/s3_reader/fetcher.ts
+++ b/asset/src/s3_reader/fetcher.ts
@@ -20,7 +20,7 @@ export default class S3Fetcher extends Fetcher<S3ReaderConfig> {
             ['op_name'],
             async function collect() {
                 const labels = {
-                    class: 's3_reader',
+                    op_name: 's3_reader',
                     ...self.context.apis.foundation.promMetrics.getDefaultLabels()
                 };
                 this.set(labels, self.getTotalReadS3Records());

--- a/asset/src/s3_reader/fetcher.ts
+++ b/asset/src/s3_reader/fetcher.ts
@@ -5,15 +5,36 @@ import { S3ReaderFactoryAPI } from '../s3_reader_api/interfaces';
 
 export default class S3Fetcher extends Fetcher<S3ReaderConfig> {
     api!: S3TerasliceAPI;
+    private s3RecordsRead = 0;
 
     async initialize(): Promise<void> {
         await super.initialize();
         const apiName = this.opConfig.api_name;
         const apiManager = this.getAPI<S3ReaderFactoryAPI>(apiName);
         this.api = await apiManager.create(apiName, {} as any);
+        const { context } = this;
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+        await this.context.apis.foundation.promMetrics.addGauge(
+            'records_read_from_s3',
+            'Number of records read from s3',
+            ['class'],
+            async function collect() {
+                const labels = {
+                    class: 'S3Fetcher',
+                    ...context.apis.foundation.promMetrics.getDefaultLabels()
+                };
+                this.set(labels, self.getTotalReadS3Records());
+            });
     }
 
     async fetch(slice: FileSlice): Promise<DataEntity[]> {
-        return this.api.read(slice);
+        const data = await this.api.read(slice);
+        this.s3RecordsRead += data.length;
+        return data;
+    }
+
+    getTotalReadS3Records(): number {
+        return this.s3RecordsRead;
     }
 }

--- a/asset/src/s3_reader/fetcher.ts
+++ b/asset/src/s3_reader/fetcher.ts
@@ -12,7 +12,6 @@ export default class S3Fetcher extends Fetcher<S3ReaderConfig> {
         const apiName = this.opConfig.api_name;
         const apiManager = this.getAPI<S3ReaderFactoryAPI>(apiName);
         this.api = await apiManager.create(apiName, {} as any);
-        const { context } = this;
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;
         await this.context.apis.foundation.promMetrics.addGauge(
@@ -22,7 +21,7 @@ export default class S3Fetcher extends Fetcher<S3ReaderConfig> {
             async function collect() {
                 const labels = {
                     class: 'S3Fetcher',
-                    ...context.apis.foundation.promMetrics.getDefaultLabels()
+                    ...self.context.apis.foundation.promMetrics.getDefaultLabels()
                 };
                 this.set(labels, self.getTotalReadS3Records());
             });

--- a/asset/src/s3_reader/fetcher.ts
+++ b/asset/src/s3_reader/fetcher.ts
@@ -17,10 +17,10 @@ export default class S3Fetcher extends Fetcher<S3ReaderConfig> {
         await this.context.apis.foundation.promMetrics.addGauge(
             'records_read_from_s3',
             'Number of records read from s3',
-            ['class'],
+            ['op_name'],
             async function collect() {
                 const labels = {
-                    class: 'S3Fetcher',
+                    class: 's3_reader',
                     ...self.context.apis.foundation.promMetrics.getDefaultLabels()
                 };
                 this.set(labels, self.getTotalReadS3Records());

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file-assets-bundle",
     "displayName": "File Assets Bundle",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": "https://github.com/terascope/file-assets.git",


### PR DESCRIPTION
This PR makes the following changes:

- Adds `records_processed_from_s3` prom metric to the `s3_exporter` operation
  - This will show up in worker pod metrics that use this operation.  
- Adds  `records_read_from_s3` prom metric to the `s3_reader` operation
  - This will show up in execution pod metrics that use this operation.  