### PR TITLE
Backwards compatibility fix for teraslice

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "file",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "A set of processors for working with files"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "^0.13.0",
-        "@terascope/job-components": "^0.74.2",
+        "@terascope/job-components": "^0.75.0",
         "csvtojson": "^2.0.10",
         "fs-extra": "^11.2.0",
         "json2csv": "5.0.7",

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file",
     "displayName": "Asset",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
         "@terascope/file-asset-apis": "^0.13.0",
-        "@terascope/job-components": "^0.74.2",
+        "@terascope/job-components": "^0.75.0",
         "@terascope/scripts": "^0.77.2",
         "@types/fs-extra": "^11.0.2",
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file-assets-bundle",
     "displayName": "File Assets Bundle",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": "https://github.com/terascope/file-assets.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,12 +1890,12 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.74.2":
-  version "0.74.2"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.74.2.tgz#de875f792644abf3324f74d98e6b7daa046d7fff"
-  integrity sha512-FEliIWkcK43Q+kiONkwutXgV/f9qQMGUjesmJq9IyqYswOd7ZHtlXCjBUziKqdUWZ01OZ3YDzFxeuufJoLflUg==
+"@terascope/job-components@^0.75.0":
+  version "0.75.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.75.0.tgz#03739729d7d7aee722b6291418987084cf65aaa9"
+  integrity sha512-QbIAKfbjX5Wj8A/hZvjE0E8y9hvW9QecQIw6eMwTRneudx2OPQcissCCYNlxBpfP13dK/U85BIqOVFZRTh8KcA==
   dependencies:
-    "@terascope/utils" "^0.59.1"
+    "@terascope/utils" "^0.59.2"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"


### PR DESCRIPTION
This PR makes the following changes:

- Introduces backwards compatibility for teraslice versions before `v1.4.0`
  - This fixes an issue where using a teraslice version older than version `v1.4.0` would throw `TypeError: this.promMetrics.addGauge is not a function`
- Bump **file-assets** to `v2.11.1`
- Updates the following dependencies:
  - **@terascope/job-components** from `v0.74.2` to `v0.75.0`

ref: https://github.com/terascope/teraslice/issues/3625