### PR TITLE
Add minimum_teraslice_version info to asset.json

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,6 @@
 {
     "name": "file",
     "version": "3.0.3",
-    "description": "A set of processors for working with files"
+    "description": "A set of processors for working with files",
+    "minimum_teraslice_version": "2.0.0"
 }


### PR DESCRIPTION
This PR makes the following changes:

- Adds a `minimum teraslice version` in the asset.json
  - This will help teraslice determine if the asset is compatible