### PR TITLE
Automate release

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -1,11 +1,15 @@
-name: Build and Publish Teraslice Asset
-run-name: ${{ github.actor }} is building and publishing the Teraslice Asset
+name: Build, Publish and Release Teraslice Asset
+run-name: ${{ github.actor }} is building, publishing and releasing the Teraslice Asset
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@f86f716e47d989b939d978befa7721c1f5b10134
+    if: github.event.pull_request.merged == true
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@2f96a27a56e68c64c67b03d000672f41379e368e
     secrets: inherit

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "file",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "description": "A set of processors for working with files",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file",
     "displayName": "Asset",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file-assets-bundle",
     "displayName": "File Assets Bundle",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": "https://github.com/terascope/file-assets.git",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "ts-jest": "~29.2.5",
         "typescript": "~5.7.3"
     },
+    "packageManager": "yarn@4.6.0",
     "engines": {
         "node": ">=18.0.0",
         "yarn": ">=1.22.19"
@@ -78,6 +79,5 @@
         "npm": {
             "registry": "https://registry.npmjs.org/"
         }
-    },
-    "packageManager": "yarn@4.6.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@types/json2csv": "~5.0.7",
         "@types/node": "~22.10.6",
         "@types/node-gzip": "~1.1.3",
+        "@types/semver": "~7.5.8",
         "eslint": "~9.18.0",
         "fs-extra": "~11.2.0",
         "jest": "~29.7.0",
@@ -49,6 +50,7 @@
         "lz4-asm": "~0.4.2",
         "node-gzip": "~1.1.2",
         "node-notifier": "~10.0.1",
+        "semver": "~7.6.3",
         "teraslice-test-harness": "~1.3.1",
         "ts-jest": "~29.2.5",
         "typescript": "~5.7.3"

--- a/test/version-sync-spec.ts
+++ b/test/version-sync-spec.ts
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import fse from 'fs-extra';
+import semver from 'semver';
+
+describe('Ensure asset.json, package.json and root package.json versions are in sync', () => {
+    it('Versions are equal', () => {
+        const pathToAssetPkgJson = path.join(process.cwd(), './asset/package.json');
+        const assetPkgJsonVersion = fse.readJSONSync(pathToAssetPkgJson).version;
+        const pathToAssetJson = path.join(process.cwd(), './asset/asset.json');
+        const assetVersion = fse.readJSONSync(pathToAssetJson).version;
+        const pathToRootPkgJson = path.join(process.cwd(), './package.json');
+        const rootVersion = fse.readJSONSync(pathToRootPkgJson).version;
+
+        expect(semver.eq(assetPkgJsonVersion, rootVersion)).toBe(true);
+        expect(semver.eq(assetVersion, rootVersion)).toBe(true);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,7 +2606,6 @@ __metadata:
   linkType: hard
 
 "@terascope/scripts@npm:^1.9.0, @terascope/scripts@npm:~1.9.0":
-"@terascope/scripts@npm:^1.9.0, @terascope/scripts@npm:~1.9.0":
   version: 1.9.0
   resolution: "@terascope/scripts@npm:1.9.0"
   dependencies:
@@ -2640,15 +2639,6 @@ __metadata:
   bin:
     ts-scripts: ./bin/ts-scripts.js
   checksum: 10c0/bddb95cf4fffa540c8cc30bed05c24dee8b71457ce5f590b5e3364188b24af63bf85ae96a68f9ffd44fa4c5b7e6465fd1ddbea94d94ef2bb04307610f5852da6
-  languageName: node
-  linkType: hard
-
-"@terascope/types@npm:~1.3.1":
-  version: 1.3.1
-  resolution: "@terascope/types@npm:1.3.1"
-  dependencies:
-    prom-client: "npm:~15.1.3"
-  checksum: 10c0/c7f06486b12780bfc2463d4f66953f8ca98c1bd893c38c8a2e86a93b8220ea34222d4c968ab3b397be6e89c7b2e6928c5416edba88edac5092f0719fe157f990
   languageName: node
   linkType: hard
 
@@ -5635,9 +5625,9 @@ __metadata:
   dependencies:
     "@terascope/eslint-config": "npm:~1.1.4"
     "@terascope/file-asset-apis": "npm:~1.0.3"
-    "@terascope/job-components": "npm:~1.8.0"
+    "@terascope/job-components": "npm:~1.9.1"
     "@terascope/scripts": "npm:~1.9.0"
-    "@types/fs-extra": "npm:~11.0.2"
+    "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~29.5.14"
     "@types/json2csv": "npm:~5.0.7"
     "@types/node": "npm:~22.10.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,6 +3178,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:~7.5.8":
+  version: 7.5.8
+  resolution: "@types/semver@npm:7.5.8"
+  checksum: 10c0/8663ff927234d1c5fcc04b33062cb2b9fcfbe0f5f351ed26c4d1e1581657deebd506b41ff7fdf89e787e3d33ce05854bc01686379b89e9c49b564c4cfa988efa
+  languageName: node
+  linkType: hard
+
 "@types/sinon@npm:^17.0.3":
   version: 17.0.3
   resolution: "@types/sinon@npm:17.0.3"
@@ -5625,6 +5632,7 @@ __metadata:
     "@types/json2csv": "npm:~5.0.7"
     "@types/node": "npm:~22.10.6"
     "@types/node-gzip": "npm:~1.1.3"
+    "@types/semver": "npm:~7.5.8"
     eslint: "npm:~9.18.0"
     fs-extra: "npm:~11.2.0"
     jest: "npm:~29.7.0"
@@ -5633,6 +5641,7 @@ __metadata:
     lz4-asm: "npm:~0.4.2"
     node-gzip: "npm:~1.1.2"
     node-notifier: "npm:~10.0.1"
+    semver: "npm:~7.6.3"
     teraslice-test-harness: "npm:~1.3.1"
     ts-jest: "npm:~29.2.5"
     typescript: "npm:~5.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,6 +2606,7 @@ __metadata:
   linkType: hard
 
 "@terascope/scripts@npm:^1.9.0, @terascope/scripts@npm:~1.9.0":
+"@terascope/scripts@npm:^1.9.0, @terascope/scripts@npm:~1.9.0":
   version: 1.9.0
   resolution: "@terascope/scripts@npm:1.9.0"
   dependencies:
@@ -2639,6 +2640,15 @@ __metadata:
   bin:
     ts-scripts: ./bin/ts-scripts.js
   checksum: 10c0/bddb95cf4fffa540c8cc30bed05c24dee8b71457ce5f590b5e3364188b24af63bf85ae96a68f9ffd44fa4c5b7e6465fd1ddbea94d94ef2bb04307610f5852da6
+  languageName: node
+  linkType: hard
+
+"@terascope/types@npm:~1.3.1":
+  version: 1.3.1
+  resolution: "@terascope/types@npm:1.3.1"
+  dependencies:
+    prom-client: "npm:~15.1.3"
+  checksum: 10c0/c7f06486b12780bfc2463d4f66953f8ca98c1bd893c38c8a2e86a93b8220ea34222d4c968ab3b397be6e89c7b2e6928c5416edba88edac5092f0719fe157f990
   languageName: node
   linkType: hard
 
@@ -5625,9 +5635,9 @@ __metadata:
   dependencies:
     "@terascope/eslint-config": "npm:~1.1.4"
     "@terascope/file-asset-apis": "npm:~1.0.3"
-    "@terascope/job-components": "npm:~1.9.1"
+    "@terascope/job-components": "npm:~1.8.0"
     "@terascope/scripts": "npm:~1.9.0"
-    "@types/fs-extra": "npm:~11.0.4"
+    "@types/fs-extra": "npm:~11.0.2"
     "@types/jest": "npm:~29.5.14"
     "@types/json2csv": "npm:~5.0.7"
     "@types/node": "npm:~22.10.6"


### PR DESCRIPTION
This PR makes the following changes:
- Update `build-and-publish-asset.yml` workflow to run on all merges to master. The workflow it triggers will now create a release, build and publish if the asset version has been bumped.
- Add test to ensure versions in `asset/asset.json`, `asset/package.json`, and `package.json` stay synced.
- bump asset from 3.0.3 to 3.0.4