### PR TITLE
[CI] remove hash from reusable workflow calls

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -11,5 +11,5 @@ on:
 jobs:
   call-asset-build:
     if: github.event.pull_request.merged == true
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@5307c8fb58de8d120cc025907cd417407f6c17cb
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@main
     secrets: inherit

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@5307c8fb58de8d120cc025907cd417407f6c17cb
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@main
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@5307c8fb58de8d120cc025907cd417407f6c17cb
+    uses: terascope/workflows/.github/workflows/asset-test.yml@main
     secrets: inherit


### PR DESCRIPTION
This PR updates all github workflow calls to the `workflows` repo to now use main instead of a specific hash.