### PR TITLE
fix @smithy/types issues in yarn lock and update aws deps

### DIFF
--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -21,8 +21,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "~3.873.0",
-        "@smithy/node-http-handler": "~4.1.1",
+        "@aws-sdk/client-s3": "~3.884.0",
+        "@smithy/node-http-handler": "~4.2.0",
         "@terascope/utils": "~1.10.2",
         "csvtojson": "~2.0.10",
         "fs-extra": "~11.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,34 +97,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:~3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/client-s3@npm:3.873.0"
+"@aws-sdk/client-s3@npm:~3.884.0":
+  version: 3.884.0
+  resolution: "@aws-sdk/client-s3@npm:3.884.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:5.2.0"
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.873.0"
-    "@aws-sdk/credential-provider-node": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
+    "@aws-sdk/credential-provider-node": "npm:3.883.0"
     "@aws-sdk/middleware-bucket-endpoint": "npm:3.873.0"
     "@aws-sdk/middleware-expect-continue": "npm:3.873.0"
-    "@aws-sdk/middleware-flexible-checksums": "npm:3.873.0"
+    "@aws-sdk/middleware-flexible-checksums": "npm:3.883.0"
     "@aws-sdk/middleware-host-header": "npm:3.873.0"
     "@aws-sdk/middleware-location-constraint": "npm:3.873.0"
-    "@aws-sdk/middleware-logger": "npm:3.873.0"
+    "@aws-sdk/middleware-logger": "npm:3.876.0"
     "@aws-sdk/middleware-recursion-detection": "npm:3.873.0"
-    "@aws-sdk/middleware-sdk-s3": "npm:3.873.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.883.0"
     "@aws-sdk/middleware-ssec": "npm:3.873.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.873.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.883.0"
     "@aws-sdk/region-config-resolver": "npm:3.873.0"
-    "@aws-sdk/signature-v4-multi-region": "npm:3.873.0"
+    "@aws-sdk/signature-v4-multi-region": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/util-endpoints": "npm:3.873.0"
+    "@aws-sdk/util-endpoints": "npm:3.879.0"
     "@aws-sdk/util-user-agent-browser": "npm:3.873.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.873.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.883.0"
     "@aws-sdk/xml-builder": "npm:3.873.0"
     "@smithy/config-resolver": "npm:^4.1.5"
-    "@smithy/core": "npm:^3.8.0"
+    "@smithy/core": "npm:^3.9.2"
     "@smithy/eventstream-serde-browser": "npm:^4.0.5"
     "@smithy/eventstream-serde-config-resolver": "npm:^4.1.3"
     "@smithy/eventstream-serde-node": "npm:^4.0.5"
@@ -135,21 +135,21 @@ __metadata:
     "@smithy/invalid-dependency": "npm:^4.0.5"
     "@smithy/md5-js": "npm:^4.0.5"
     "@smithy/middleware-content-length": "npm:^4.0.5"
-    "@smithy/middleware-endpoint": "npm:^4.1.18"
-    "@smithy/middleware-retry": "npm:^4.1.19"
+    "@smithy/middleware-endpoint": "npm:^4.1.21"
+    "@smithy/middleware-retry": "npm:^4.1.22"
     "@smithy/middleware-serde": "npm:^4.0.9"
     "@smithy/middleware-stack": "npm:^4.0.5"
     "@smithy/node-config-provider": "npm:^4.1.4"
     "@smithy/node-http-handler": "npm:^4.1.1"
     "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.4.10"
+    "@smithy/smithy-client": "npm:^4.5.2"
     "@smithy/types": "npm:^4.3.2"
     "@smithy/url-parser": "npm:^4.0.5"
     "@smithy/util-base64": "npm:^4.0.0"
     "@smithy/util-body-length-browser": "npm:^4.0.0"
     "@smithy/util-body-length-node": "npm:^4.0.0"
-    "@smithy/util-defaults-mode-browser": "npm:^4.0.26"
-    "@smithy/util-defaults-mode-node": "npm:^4.0.26"
+    "@smithy/util-defaults-mode-browser": "npm:^4.0.29"
+    "@smithy/util-defaults-mode-node": "npm:^4.0.29"
     "@smithy/util-endpoints": "npm:^3.0.7"
     "@smithy/util-middleware": "npm:^4.0.5"
     "@smithy/util-retry": "npm:^4.0.7"
@@ -159,68 +159,68 @@ __metadata:
     "@types/uuid": "npm:^9.0.1"
     tslib: "npm:^2.6.2"
     uuid: "npm:^9.0.1"
-  checksum: 10c0/054d8f5489f7c56422ac0c918cb3977dce7c17693dba756eebbd06a4df6bfcb2fc1acd94a3990357f17976589b3c09951f573677670bc74cd3d88e3b54dd1ba1
+  checksum: 10c0/6a593ce77679b118e9d17ad62d2702b97deb2e196fb6f1734e83307856db370b5d94390e9bd54860c176b31334413d963ed5920403fab199dbd9f147ff479925
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/client-sso@npm:3.873.0"
+"@aws-sdk/client-sso@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/client-sso@npm:3.883.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
     "@aws-sdk/middleware-host-header": "npm:3.873.0"
-    "@aws-sdk/middleware-logger": "npm:3.873.0"
+    "@aws-sdk/middleware-logger": "npm:3.876.0"
     "@aws-sdk/middleware-recursion-detection": "npm:3.873.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.873.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.883.0"
     "@aws-sdk/region-config-resolver": "npm:3.873.0"
     "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/util-endpoints": "npm:3.873.0"
+    "@aws-sdk/util-endpoints": "npm:3.879.0"
     "@aws-sdk/util-user-agent-browser": "npm:3.873.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.873.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.883.0"
     "@smithy/config-resolver": "npm:^4.1.5"
-    "@smithy/core": "npm:^3.8.0"
+    "@smithy/core": "npm:^3.9.2"
     "@smithy/fetch-http-handler": "npm:^5.1.1"
     "@smithy/hash-node": "npm:^4.0.5"
     "@smithy/invalid-dependency": "npm:^4.0.5"
     "@smithy/middleware-content-length": "npm:^4.0.5"
-    "@smithy/middleware-endpoint": "npm:^4.1.18"
-    "@smithy/middleware-retry": "npm:^4.1.19"
+    "@smithy/middleware-endpoint": "npm:^4.1.21"
+    "@smithy/middleware-retry": "npm:^4.1.22"
     "@smithy/middleware-serde": "npm:^4.0.9"
     "@smithy/middleware-stack": "npm:^4.0.5"
     "@smithy/node-config-provider": "npm:^4.1.4"
     "@smithy/node-http-handler": "npm:^4.1.1"
     "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.4.10"
+    "@smithy/smithy-client": "npm:^4.5.2"
     "@smithy/types": "npm:^4.3.2"
     "@smithy/url-parser": "npm:^4.0.5"
     "@smithy/util-base64": "npm:^4.0.0"
     "@smithy/util-body-length-browser": "npm:^4.0.0"
     "@smithy/util-body-length-node": "npm:^4.0.0"
-    "@smithy/util-defaults-mode-browser": "npm:^4.0.26"
-    "@smithy/util-defaults-mode-node": "npm:^4.0.26"
+    "@smithy/util-defaults-mode-browser": "npm:^4.0.29"
+    "@smithy/util-defaults-mode-node": "npm:^4.0.29"
     "@smithy/util-endpoints": "npm:^3.0.7"
     "@smithy/util-middleware": "npm:^4.0.5"
     "@smithy/util-retry": "npm:^4.0.7"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/fe8e19572c128465162a39e68526fdc2eade75db81fbf30fdd2d4dc79679f108dc985c8e57e76565ee46d6179bef37347ad4d2c83bb8d9e021ca3f53c2d27f33
+  checksum: 10c0/972315c4d0560af7a0d9ca7421b8820306c8f4b4a4359e68352a63af3e50f4160a861b7ffb4f3e26f4cf9f9818a4d4f47f9daeee4f97b7bb24e27b568b79226a
   languageName: node
   linkType: hard
 
-"@aws-sdk/core@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/core@npm:3.873.0"
+"@aws-sdk/core@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/core@npm:3.883.0"
   dependencies:
     "@aws-sdk/types": "npm:3.862.0"
     "@aws-sdk/xml-builder": "npm:3.873.0"
-    "@smithy/core": "npm:^3.8.0"
+    "@smithy/core": "npm:^3.9.2"
     "@smithy/node-config-provider": "npm:^4.1.4"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/protocol-http": "npm:^5.1.3"
     "@smithy/signature-v4": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.4.10"
+    "@smithy/smithy-client": "npm:^4.5.2"
     "@smithy/types": "npm:^4.3.2"
     "@smithy/util-base64": "npm:^4.0.0"
     "@smithy/util-body-length-browser": "npm:^4.0.0"
@@ -228,123 +228,123 @@ __metadata:
     "@smithy/util-utf8": "npm:^4.0.0"
     fast-xml-parser: "npm:5.2.5"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/894af2a10e29ef37cf59854d3c52b7e0b3f040ba440a47a257258a43a1a0b39f959c72bfe4380e52a39ff3e947a3cafe0eabcd5b2fea26dccf9f6355d84f2595
+  checksum: 10c0/c3416b83df0f9ac3c0ac05deaea0d9616bc72d189327fd2a6249c6b976f6d5c36a3fa9f9b27bc881f5be48efddf518d8d79f3677f482ad10080c4edd58a6e9c4
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.873.0"
+"@aws-sdk/credential-provider-env@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.883.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/2763cc38bfd9e516d3651024fe43320b0fb6dee144b7e6fed52661baec57aca661b8c9ee102662748e38ddc7c7fc4b6b20df782fcb5502c48170d7cb87e3ca29
+  checksum: 10c0/be028db70cf9d24857aee5c336af778c99cfcfef3493ce905b041e60b637aedd2ec164757fe9ef3a01d292146cb416ef4a5a1468ab42f05b5b77c5fc7d55d36e
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-http@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/credential-provider-http@npm:3.873.0"
+"@aws-sdk/credential-provider-http@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.883.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/fetch-http-handler": "npm:^5.1.1"
     "@smithy/node-http-handler": "npm:^4.1.1"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.4.10"
+    "@smithy/smithy-client": "npm:^4.5.2"
     "@smithy/types": "npm:^4.3.2"
     "@smithy/util-stream": "npm:^4.2.4"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/50cc6f3fdbbfe518c3e7fd93a05fd54a24c6f30269b924465a5a8b391030f37769c742ddb5572e4a3ec9180043f1f07855d8d7d5a39698e2957e1bb1f91749df
+  checksum: 10c0/5487b9691e2775d5a933940571153a8ce9f639d1cf19c92ae263ea97033d2c8158b97be41cba58a6b59b1405333c00c50e204a192faad9d5231b2f633d28a444
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.873.0"
+"@aws-sdk/credential-provider-ini@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.883.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.873.0"
-    "@aws-sdk/credential-provider-env": "npm:3.873.0"
-    "@aws-sdk/credential-provider-http": "npm:3.873.0"
-    "@aws-sdk/credential-provider-process": "npm:3.873.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.873.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.873.0"
-    "@aws-sdk/nested-clients": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
+    "@aws-sdk/credential-provider-env": "npm:3.883.0"
+    "@aws-sdk/credential-provider-http": "npm:3.883.0"
+    "@aws-sdk/credential-provider-process": "npm:3.883.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.883.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.883.0"
+    "@aws-sdk/nested-clients": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/credential-provider-imds": "npm:^4.0.7"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/5c314a7ae80eb7a05616186f9fd26b523b4e97b5df59cf3e8be501b3167335abb62f74f1153a73f601fbbe3588d8f182c585477b555b9f59db9a26e493440d4d
+  checksum: 10c0/d642df1224842c9f882406b7de0059e2efd6ab44c7994ed49bdc2aa0450b0dccbc561998df6fa3f9d1bee48edc4ad1bd985f56ab3eb3672db574a3ffe6735a9d
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.873.0"
+"@aws-sdk/credential-provider-node@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.883.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.873.0"
-    "@aws-sdk/credential-provider-http": "npm:3.873.0"
-    "@aws-sdk/credential-provider-ini": "npm:3.873.0"
-    "@aws-sdk/credential-provider-process": "npm:3.873.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.873.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.873.0"
+    "@aws-sdk/credential-provider-env": "npm:3.883.0"
+    "@aws-sdk/credential-provider-http": "npm:3.883.0"
+    "@aws-sdk/credential-provider-ini": "npm:3.883.0"
+    "@aws-sdk/credential-provider-process": "npm:3.883.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.883.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/credential-provider-imds": "npm:^4.0.7"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/1a8129d392e5e7975419fa54fa6995efc75784daf3a8a367f4bce0bb088d87405ce35b6c3e3f28b96c1517fee44068aebc3707988dcafce19c825c4573a68ff3
+  checksum: 10c0/7b8a495bf4c55766a53c79899055ea1051b5823e02ea36fea59774e24d92d8446a68386a2ea04dcec769e8ea0526da545e5de5eb8e9b537ac124b20d1ceff798
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.873.0"
+"@aws-sdk/credential-provider-process@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.883.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d1502eb5af899dfa34dc7bf5f57702558b1483a1db17e5cc9191bdd784dd01f0cbd09a4e9c0bcff30c75ac903d043aecf774a546cf507f97cf658e617ab7ffeb
+  checksum: 10c0/9d6d89059dfd00172d492cd77f7b21c29c14ccd2a877ca2e141c2a5f58a57a33bcb588cfa9d5993f599b80be7e39313b37fa9ac81f646eedd299fbafc8202a8c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.873.0"
+"@aws-sdk/credential-provider-sso@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.883.0"
   dependencies:
-    "@aws-sdk/client-sso": "npm:3.873.0"
-    "@aws-sdk/core": "npm:3.873.0"
-    "@aws-sdk/token-providers": "npm:3.873.0"
+    "@aws-sdk/client-sso": "npm:3.883.0"
+    "@aws-sdk/core": "npm:3.883.0"
+    "@aws-sdk/token-providers": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/6ec9c3b956ea24455045e400be8defcfb232fd4826664a3e7eb81540daedbc8a1c0ded2c77e94d2ae39e2613118f513ca71b55e126ee4ec157c4155b4cd9d653
+  checksum: 10c0/23557b036221200407a7b446f40511178c55b2f6ef75c3c94f5ab16e8d119e49fd8ad7fba969d45fa24cdcf1f30f1e0ccf0bb95573e860744fc8bd9af9a1055e
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.873.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.883.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.873.0"
-    "@aws-sdk/nested-clients": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
+    "@aws-sdk/nested-clients": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d0a205a595face1e568d34448d7eeed5c39dc1b1c6d8d4a293ac70ac0f90e48837c9ec3c55320a403989ac8b5a831b8f7a78429d3843239fbfcc1e27be4fcdba
+  checksum: 10c0/55fcfd5a2bb9e6762b26c3c37da0b48b8677dc60067f97ca0b941420e23ac6cce4e2bd577282ce3116a296f9cc9cd6af846cc50486f0bc8f1898b77f9a37f7e5
   languageName: node
   linkType: hard
 
@@ -375,14 +375,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-flexible-checksums@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.873.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.883.0"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
     "@aws-crypto/crc32c": "npm:5.2.0"
     "@aws-crypto/util": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/is-array-buffer": "npm:^4.0.0"
     "@smithy/node-config-provider": "npm:^4.1.4"
@@ -392,7 +392,7 @@ __metadata:
     "@smithy/util-stream": "npm:^4.2.4"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4286a68d03157e98e84ca9bec530ef1c734c654984485db778a322749cf787af3f273eedaf38a7e43a72c4a538d22035b68c8b7cb562adaae798d5b0e054de8e
+  checksum: 10c0/c5ab881cb3e30dc8a003f131be60634375981cba6b55c1098f186484aa2779c8991af8279bfcbf4cfe688294cef09489f8924516f3d0a271efb5fd56496520b3
   languageName: node
   linkType: hard
 
@@ -419,14 +419,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.873.0"
+"@aws-sdk/middleware-logger@npm:3.876.0":
+  version: 3.876.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.876.0"
   dependencies:
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/12fbb3c98a5873807834d983189470cee8371ca34b9ba3bdca31e3a81c011b35be260278ae8b3baf64385d4741c001d0749c2686f0747f64a801825084351efb
+  checksum: 10c0/8a4b31102579bbdabc22f982277239535627e658fce8cff32df4032c510ec944ce4ffef73ae6cd948b918f87809133c6e3e3f7fdd60bd6feec89f4cbab4300c8
   languageName: node
   linkType: hard
 
@@ -442,25 +442,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.873.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.883.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@aws-sdk/util-arn-parser": "npm:3.873.0"
-    "@smithy/core": "npm:^3.8.0"
+    "@smithy/core": "npm:^3.9.2"
     "@smithy/node-config-provider": "npm:^4.1.4"
     "@smithy/protocol-http": "npm:^5.1.3"
     "@smithy/signature-v4": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.4.10"
+    "@smithy/smithy-client": "npm:^4.5.2"
     "@smithy/types": "npm:^4.3.2"
     "@smithy/util-config-provider": "npm:^4.0.0"
     "@smithy/util-middleware": "npm:^4.0.5"
     "@smithy/util-stream": "npm:^4.2.4"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8bac428749123994b04e51ba2893a04e53022933a21fed4abbcef8f013014f7f1673fecb490285a123c484fa3e7c4d1e64fb8c679e6d1f259a1ecc03e0e553ef
+  checksum: 10c0/8ad3003b1ebc462be49ead4c687b78d9aee863ecc28cc4876db00762815c5e8cc1e1bc6e39faee6644a06b24325536fd8a5e1195bf93b0336fb6b641f821aabb
   languageName: node
   linkType: hard
 
@@ -475,64 +475,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.873.0"
+"@aws-sdk/middleware-user-agent@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.883.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/util-endpoints": "npm:3.873.0"
-    "@smithy/core": "npm:^3.8.0"
+    "@aws-sdk/util-endpoints": "npm:3.879.0"
+    "@smithy/core": "npm:^3.9.2"
     "@smithy/protocol-http": "npm:^5.1.3"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4cdd2d08f206099900dff674eda0a115e09b8a809d9a420baf720cc096949d82ca9f6e9f78d2a06534af9a7be3b59ac126f200ccd5dc61699fa1371422184e14
+  checksum: 10c0/dfb27c854a35f74258f3a8b2fed2250a155496956e6cc2c664bdc444c92fc085c26573837e83e02735adc06a1815f3faa73195bc125bf4563f1b7c91081e6870
   languageName: node
   linkType: hard
 
-"@aws-sdk/nested-clients@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/nested-clients@npm:3.873.0"
+"@aws-sdk/nested-clients@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/nested-clients@npm:3.883.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
     "@aws-sdk/middleware-host-header": "npm:3.873.0"
-    "@aws-sdk/middleware-logger": "npm:3.873.0"
+    "@aws-sdk/middleware-logger": "npm:3.876.0"
     "@aws-sdk/middleware-recursion-detection": "npm:3.873.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.873.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.883.0"
     "@aws-sdk/region-config-resolver": "npm:3.873.0"
     "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/util-endpoints": "npm:3.873.0"
+    "@aws-sdk/util-endpoints": "npm:3.879.0"
     "@aws-sdk/util-user-agent-browser": "npm:3.873.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.873.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.883.0"
     "@smithy/config-resolver": "npm:^4.1.5"
-    "@smithy/core": "npm:^3.8.0"
+    "@smithy/core": "npm:^3.9.2"
     "@smithy/fetch-http-handler": "npm:^5.1.1"
     "@smithy/hash-node": "npm:^4.0.5"
     "@smithy/invalid-dependency": "npm:^4.0.5"
     "@smithy/middleware-content-length": "npm:^4.0.5"
-    "@smithy/middleware-endpoint": "npm:^4.1.18"
-    "@smithy/middleware-retry": "npm:^4.1.19"
+    "@smithy/middleware-endpoint": "npm:^4.1.21"
+    "@smithy/middleware-retry": "npm:^4.1.22"
     "@smithy/middleware-serde": "npm:^4.0.9"
     "@smithy/middleware-stack": "npm:^4.0.5"
     "@smithy/node-config-provider": "npm:^4.1.4"
     "@smithy/node-http-handler": "npm:^4.1.1"
     "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.4.10"
+    "@smithy/smithy-client": "npm:^4.5.2"
     "@smithy/types": "npm:^4.3.2"
     "@smithy/url-parser": "npm:^4.0.5"
     "@smithy/util-base64": "npm:^4.0.0"
     "@smithy/util-body-length-browser": "npm:^4.0.0"
     "@smithy/util-body-length-node": "npm:^4.0.0"
-    "@smithy/util-defaults-mode-browser": "npm:^4.0.26"
-    "@smithy/util-defaults-mode-node": "npm:^4.0.26"
+    "@smithy/util-defaults-mode-browser": "npm:^4.0.29"
+    "@smithy/util-defaults-mode-node": "npm:^4.0.29"
     "@smithy/util-endpoints": "npm:^3.0.7"
     "@smithy/util-middleware": "npm:^4.0.5"
     "@smithy/util-retry": "npm:^4.0.7"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/1adfee407ce16b5cd9b8087d2514d3b42df07589300f775dedaecbeb7b485940df4846a4795b9e34269e8cde1e2a6a7aefe8dd9d7c67506d72b11db1c0785d4c
+  checksum: 10c0/e894c9dd161d0bc5c069803ef4178991f4ccbc8f46d2172425898923a1a0a8c04546c80a56223f2f5c6f18173b9f557d78f6b55e39a1cfab5cc578425706b819
   languageName: node
   linkType: hard
 
@@ -550,32 +550,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.873.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.883.0"
   dependencies:
-    "@aws-sdk/middleware-sdk-s3": "npm:3.873.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/protocol-http": "npm:^5.1.3"
     "@smithy/signature-v4": "npm:^5.1.3"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/bf39a7902bec6f66f3881b0a426b57253959e808da46e6870e14897e357ac995c387b0bd00790bfea7725a1ed2940dea54b7174789b22a4d0faa63b79f963afd
+  checksum: 10c0/c426415461ca6aee0ad5fd54d72a2cdd119ae01a651fd2d9222c6bcef5fcecb87a9ce5d6e81581665ccb81d10955e07c4d47b65545f1792c03c646c3c629ba4d
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/token-providers@npm:3.873.0"
+"@aws-sdk/token-providers@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/token-providers@npm:3.883.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.873.0"
-    "@aws-sdk/nested-clients": "npm:3.873.0"
+    "@aws-sdk/core": "npm:3.883.0"
+    "@aws-sdk/nested-clients": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/fb56b26781c3b65e23149ee406d2e45b85d41fdf28b51d4f26762c09137d4c1b3a3726fd28a530b59d9b4d039917ecab235d8865ce9cabe0d1141d207115a16b
+  checksum: 10c0/7f329c4c0fb23f2d8b18e26b82f142655163c6ecc93014730cb465040d3c8aa9d63fb877c936cd20684c3d1d8eee87bbcfb515fda146a79f37a28d7bb64ac0df
   languageName: node
   linkType: hard
 
@@ -608,16 +608,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-endpoints@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.873.0"
+"@aws-sdk/util-endpoints@npm:3.879.0":
+  version: 3.879.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.879.0"
   dependencies:
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/types": "npm:^4.3.2"
     "@smithy/url-parser": "npm:^4.0.5"
     "@smithy/util-endpoints": "npm:^3.0.7"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/663b882c69400f6473d5d3acd7c337031412bc86d2edd60a1f3faa40c575a79f0a2927b03b0b059453c43cc818e05fb6da0e4b8ab7f960d1c9d2a2b7de952a4d
+  checksum: 10c0/abf709bbdaf26f5920f41e105a153a959e0451b88c047957181b7ad834b1b5914d72728a89142a3921c389485a173537a8e0505ff4b308276b5334cbbd7fd60a
   languageName: node
   linkType: hard
 
@@ -642,11 +642,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.873.0"
+"@aws-sdk/util-user-agent-node@npm:3.883.0":
+  version: 3.883.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.883.0"
   dependencies:
-    "@aws-sdk/middleware-user-agent": "npm:3.873.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.883.0"
     "@aws-sdk/types": "npm:3.862.0"
     "@smithy/node-config-provider": "npm:^4.1.4"
     "@smithy/types": "npm:^4.3.2"
@@ -656,7 +656,7 @@ __metadata:
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 10c0/84e5a97d5d4b2a3e86e8521d0a6deec02ef990841024cdc5de0bd1585fcd2ae58c140f68e22a28b625e9f4900035c526f9ec8cb65078852fae5272690583cf25
+  checksum: 10c0/440ba1130df97f0a4899e0d9245993ce579cb54edad427534c90bb6e37c2b3aa48951527bb07598f0505c8117f282c984ce7e2ec4270a7be07f6f9720c06eafd
   languageName: node
   linkType: hard
 
@@ -2109,6 +2109,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/abort-controller@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/abort-controller@npm:4.1.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/fd70202a85b9821e1ba1b326c16e8d0d7a5662b9a0c208b255c03f601abe9ec7d9024c27acaa3b70a3c1c0aec4153e9dab90df526f42a298ebc1dd8b3519c2a1
+  languageName: node
+  linkType: hard
+
 "@smithy/chunked-blob-reader-native@npm:^4.0.0":
   version: 4.0.0
   resolution: "@smithy/chunked-blob-reader-native@npm:4.0.0"
@@ -2141,22 +2151,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "@smithy/core@npm:3.8.0"
+"@smithy/config-resolver@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@smithy/config-resolver@npm:4.2.0"
   dependencies:
-    "@smithy/middleware-serde": "npm:^4.0.9"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-base64": "npm:^4.0.0"
-    "@smithy/util-body-length-browser": "npm:^4.0.0"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    "@smithy/util-stream": "npm:^4.2.4"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@smithy/node-config-provider": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/util-config-provider": "npm:^4.1.0"
+    "@smithy/util-middleware": "npm:^4.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a4b957028f60a27d2fe2611e4a972321d96987f92fe0b7ce65c1279c29b2cbd5a5f256a541a5648da06c5abef16b31a5ac94688af1af719bab39cd4c9f98dd2b
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^3.10.0, @smithy/core@npm:^3.9.2":
+  version: 3.10.0
+  resolution: "@smithy/core@npm:3.10.0"
+  dependencies:
+    "@smithy/middleware-serde": "npm:^4.1.0"
+    "@smithy/protocol-http": "npm:^5.2.0"
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/util-base64": "npm:^4.1.0"
+    "@smithy/util-body-length-browser": "npm:^4.1.0"
+    "@smithy/util-middleware": "npm:^4.1.0"
+    "@smithy/util-stream": "npm:^4.3.0"
+    "@smithy/util-utf8": "npm:^4.1.0"
     "@types/uuid": "npm:^9.0.1"
     tslib: "npm:^2.6.2"
     uuid: "npm:^9.0.1"
-  checksum: 10c0/0fe1c19b0a2f371ed04b47e51edac896ed24d868a3f78290ea8913e255fef7d023a9c0ba252f5af2b606bfadfdca7fbc545db01dcd0d2162c228d10b2eadc303
+  checksum: 10c0/a30742bc4d5aeef0e0480a0d60caa9e4fd3ed76d7e519fe354357538cc06712db4105c855ca50c2d8d2a45b00edc88f0a68ffa0b49c1cf1e6457d91a8a0e8ee7
   languageName: node
   linkType: hard
 
@@ -2170,6 +2193,19 @@ __metadata:
     "@smithy/url-parser": "npm:^4.0.5"
     tslib: "npm:^2.6.2"
   checksum: 10c0/862ac40520e2756918e8ecdf2259ec82f1b1556595b3b8d19d7c68390119c416fdd9c716c78773a2ccec21c32cb81f465e0474073a8a90808e171fbdcdcfbd81
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/credential-provider-imds@npm:4.1.0"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^4.2.0"
+    "@smithy/property-provider": "npm:^4.1.0"
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/url-parser": "npm:^4.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e61013df07855c8f0275343d6b981948b62b86ce3a883111e5784be63e5bab307e0e1227ec97bce64f706dbdb4cb22d65ccf4cd231d4a96e3b0b1c06793d3063
   languageName: node
   linkType: hard
 
@@ -2241,6 +2277,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/fetch-http-handler@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@smithy/fetch-http-handler@npm:5.2.0"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.2.0"
+    "@smithy/querystring-builder": "npm:^4.1.0"
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/util-base64": "npm:^4.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f8d2a9b169ba11f21c290e529768c874768926e59968bda6443b918ab2c3c205c97be85461e457c08f73dc2a65e3afd485826ff9636d0a1bb4affb7059f16532
+  languageName: node
+  linkType: hard
+
 "@smithy/hash-blob-browser@npm:^4.0.5":
   version: 4.0.5
   resolution: "@smithy/hash-blob-browser@npm:4.0.5"
@@ -2304,6 +2353,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/is-array-buffer@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/is-array-buffer@npm:4.1.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/399af810a9329c033d1816c492b17343d2ff956d32a358f327da6af0e4ad3c4640a1ef8dcd5f4d0f7d85ef19cf6909038f1a6539c938372dd33996d8f102bb9a
+  languageName: node
+  linkType: hard
+
 "@smithy/md5-js@npm:^4.0.5":
   version: 4.0.5
   resolution: "@smithy/md5-js@npm:4.0.5"
@@ -2326,37 +2384,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^4.1.18":
-  version: 4.1.18
-  resolution: "@smithy/middleware-endpoint@npm:4.1.18"
+"@smithy/middleware-endpoint@npm:^4.1.21, @smithy/middleware-endpoint@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@smithy/middleware-endpoint@npm:4.2.0"
   dependencies:
-    "@smithy/core": "npm:^3.8.0"
-    "@smithy/middleware-serde": "npm:^4.0.9"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/shared-ini-file-loader": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/url-parser": "npm:^4.0.5"
-    "@smithy/util-middleware": "npm:^4.0.5"
+    "@smithy/core": "npm:^3.10.0"
+    "@smithy/middleware-serde": "npm:^4.1.0"
+    "@smithy/node-config-provider": "npm:^4.2.0"
+    "@smithy/shared-ini-file-loader": "npm:^4.1.0"
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/url-parser": "npm:^4.1.0"
+    "@smithy/util-middleware": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/22a6e05e427c9899041facefea8bdf8dad393bdb3ccd7ca795fb705e85ee8b9e48c6000e947bb6a8a1cfe48d1f1f1b9f894f0b588e87ce1ea5b187d041bcd6fe
+  checksum: 10c0/70704d829828f96c02ba6ecb1621b3e1329fea631efa261a96e0daf9bafbd91d6859c5d51c230575e9b4bac27c73d57b3ad054fe24716e14627bd948c66e7124
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^4.1.19":
-  version: 4.1.19
-  resolution: "@smithy/middleware-retry@npm:4.1.19"
+"@smithy/middleware-retry@npm:^4.1.22":
+  version: 4.2.0
+  resolution: "@smithy/middleware-retry@npm:4.2.0"
   dependencies:
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/service-error-classification": "npm:^4.0.7"
-    "@smithy/smithy-client": "npm:^4.4.10"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    "@smithy/util-retry": "npm:^4.0.7"
+    "@smithy/node-config-provider": "npm:^4.2.0"
+    "@smithy/protocol-http": "npm:^5.2.0"
+    "@smithy/service-error-classification": "npm:^4.1.0"
+    "@smithy/smithy-client": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/util-middleware": "npm:^4.1.0"
+    "@smithy/util-retry": "npm:^4.1.0"
     "@types/uuid": "npm:^9.0.1"
     tslib: "npm:^2.6.2"
     uuid: "npm:^9.0.1"
-  checksum: 10c0/6595d27404491ee3befc69ffe8ce576f26b409385d6958597c8d889fff7aff26973a54eab605348299c24760912d9606f7efe84e3adf72ab146b114096592bec
+  checksum: 10c0/ee68ece2a077fd4f73522c9d404fa584df100ed0aa0f049f65bf1d48924e084ded9daf897d557e83a86b498c34d59011ad2291b89b4bcd68a4482a5b72cee186
   languageName: node
   linkType: hard
 
@@ -2371,6 +2429,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-serde@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/middleware-serde@npm:4.1.0"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.2.0"
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/cc44022522777c05445db06c15acd7886a23b1c499ae38b73b1153e8b10752feca644ece54168c5180b114201ea82f1b713dd5da6cf5a4c7374accde34346f71
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-stack@npm:^4.0.5":
   version: 4.0.5
   resolution: "@smithy/middleware-stack@npm:4.0.5"
@@ -2378,6 +2447,16 @@ __metadata:
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/2ebe346b8b868d11bf9e5028a225ad1312f7862231ae01c289059291b984127a7c18e17f1fa4d803de09f77441d839bc5e25f8ec9bed10a9a320d0393bc55930
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-stack@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/middleware-stack@npm:4.1.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4437f06e263587138030d6b1f6612aa4848041ab398999f626da8f3954c6046ec0e602c28daa451eeeab365b7812805fd1afc2562ad267a102f3de6f62625c58
   languageName: node
   linkType: hard
 
@@ -2393,7 +2472,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^4.1.1, @smithy/node-http-handler@npm:~4.1.1":
+"@smithy/node-config-provider@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@smithy/node-config-provider@npm:4.2.0"
+  dependencies:
+    "@smithy/property-provider": "npm:^4.1.0"
+    "@smithy/shared-ini-file-loader": "npm:^4.1.0"
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/785af2cbfb8c5cd7a67069230f62f84c6492742bc622791375675a519d743dc7965854aea5bfcaa3b92ba9f3cdebe99786570bb6919dbe89ac245130254c0bd0
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.1.1":
   version: 4.1.1
   resolution: "@smithy/node-http-handler@npm:4.1.1"
   dependencies:
@@ -2403,6 +2494,19 @@ __metadata:
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/a61a841bc6e69c62a983031e8b3faf1ab82abaf0ccd1eb5d3e02e3d99a8be020fa8dff0b2b1f81468db43e0e7be2407785b89e9c6c04035b8b4afde08bed3a98
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.2.0, @smithy/node-http-handler@npm:~4.2.0":
+  version: 4.2.0
+  resolution: "@smithy/node-http-handler@npm:4.2.0"
+  dependencies:
+    "@smithy/abort-controller": "npm:^4.1.0"
+    "@smithy/protocol-http": "npm:^5.2.0"
+    "@smithy/querystring-builder": "npm:^4.1.0"
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2b899b5fb709d635fa0c4da1482436965cfa8c9bda1663936c3ceb458a54ada64f6deb2e6ca832d618942bbcbbf900e823689259f5b709164c07d33718e0da23
   languageName: node
   linkType: hard
 
@@ -2416,6 +2520,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/property-provider@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/property-provider@npm:4.1.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a2af26b4e0dfefebb998decd9d4b19349030b3cdebc6fc3287974f06c8207e9b0b40a4f56a9a950d21711dcb580644e47db5c6b66a1f8f2f6a774865681a763a
+  languageName: node
+  linkType: hard
+
 "@smithy/protocol-http@npm:^5.1.3":
   version: 5.1.3
   resolution: "@smithy/protocol-http@npm:5.1.3"
@@ -2423,6 +2537,16 @@ __metadata:
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/5adc1e69b9e2d7c90acfe1a9b731c4f233173e035eb9e8e3dd5fabf63d9a765aff54912a0e94f4f4bff494f4caa9ec40bd53cdc1a94028f561ab5c9649f2790f
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@smithy/protocol-http@npm:5.2.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a1e0212b55fa071d89189fc8a5f339499e8862f567f5e4c2888c53eece3815939221684d6bd6782d8b572305734cf3bb229a29f13273671f810c804fa50833d3
   languageName: node
   linkType: hard
 
@@ -2437,6 +2561,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/querystring-builder@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/querystring-builder@npm:4.1.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/util-uri-escape": "npm:^4.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/54b0f19970b90ee0efa52611007c3c096bb99028bce0da88beb7ccf8548db46332c7012776fd3ce17ae927c89c03e6a9471b874fce9469b99edd3a02c9d56e7e
+  languageName: node
+  linkType: hard
+
 "@smithy/querystring-parser@npm:^4.0.5":
   version: 4.0.5
   resolution: "@smithy/querystring-parser@npm:4.0.5"
@@ -2444,6 +2579,16 @@ __metadata:
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e12a2e19137bc95487c51652dd20f6cd0199854986019e5461f14f797fda3cda3ec4786ff45af853aa64ab75a2a91d18f3f8320276f7e407016f80e33604564d
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-parser@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/querystring-parser@npm:4.1.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/88e698853f9e7e481ed05fa6dca27e60a0206cc0efb1770e29c2f6a8850be5f49d7f75618c198da143f1a39631522fae7a9635e8d4d22d6167df421f80017726
   languageName: node
   linkType: hard
 
@@ -2456,6 +2601,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/service-error-classification@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/service-error-classification@npm:4.1.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+  checksum: 10c0/14f65f54aea8f5598e69d6d22e2c44c3f790434837701ac04627f51791551af094d8c26a6b8ef752c8f8d3fbec2dd6a268c33d40e6af1a0bade9ac3cb905bc41
+  languageName: node
+  linkType: hard
+
 "@smithy/shared-ini-file-loader@npm:^4.0.5":
   version: 4.0.5
   resolution: "@smithy/shared-ini-file-loader@npm:4.0.5"
@@ -2463,6 +2617,16 @@ __metadata:
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/9fafb7d4cf10398cf07a2ad7b619b05f136a2a774b1d104eb43b1862f1297d1f88f7e6d72198df43bef35cdf5938b8b5bcf0e896a8bb406474920d0f653a0a4b
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/shared-ini-file-loader@npm:4.1.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c3dab2b4c4844ddd38d8862c6bed03e442c1d8c70d88b81d8f1597bb61a21142ce63a6eb802236cc7690468b7d7eb69c49e4e5d08693d12a4b9c4109c2ccff12
   languageName: node
   linkType: hard
 
@@ -2482,18 +2646,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^4.4.10":
-  version: 4.4.10
-  resolution: "@smithy/smithy-client@npm:4.4.10"
+"@smithy/smithy-client@npm:^4.5.2, @smithy/smithy-client@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "@smithy/smithy-client@npm:4.6.0"
   dependencies:
-    "@smithy/core": "npm:^3.8.0"
-    "@smithy/middleware-endpoint": "npm:^4.1.18"
-    "@smithy/middleware-stack": "npm:^4.0.5"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-stream": "npm:^4.2.4"
+    "@smithy/core": "npm:^3.10.0"
+    "@smithy/middleware-endpoint": "npm:^4.2.0"
+    "@smithy/middleware-stack": "npm:^4.1.0"
+    "@smithy/protocol-http": "npm:^5.2.0"
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/util-stream": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/994743c7a04e3e1b5136c3be98c3882ab9169d39143530c11553062934887b6b9b7d32de035a15f7ff0f7e6b5db6106ab3e71dc62beb473da9313ff6b8b24a37
+  checksum: 10c0/d8d6ccf506d1cffae967565442aa28a288cd97fd2f88d14cf359b18ab99cbe99001421bcc3b6a49b766fe63222e87cb9debe74f372d9756242b8c5ef891c5c43
   languageName: node
   linkType: hard
 
@@ -2506,12 +2670,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "@smithy/types@npm:4.3.2"
+"@smithy/types@npm:^4.3.2, @smithy/types@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "@smithy/types@npm:4.4.0"
   dependencies:
     tslib: "npm:^2.6.2"
-  checksum: 10c0/120c5d38f6362c86e6493cce3b9ca9902cd986dab773b39664ff6a95b787c45481f1b1d230f45a6f5ad0c045fb690dc96b51b9ca7b5e9487714a652ed98231f6
+  checksum: 10c0/af7b78cf16be45c65b3e4dcde37589e49d501981f53ce9d3382d66d60b22d975bccfcf417fb42eae59416215d581b0f6136be04ebf17e88bc0dc91b47d2dddd1
   languageName: node
   linkType: hard
 
@@ -2526,6 +2690,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/url-parser@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/url-parser@npm:4.1.0"
+  dependencies:
+    "@smithy/querystring-parser": "npm:^4.1.0"
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/be71635e8fcbcf6868a461f71459d82d8ae619277454609ff70d848c92043d1dc4fc521149f0b6372e76b227aabdf11094a65c8bf64eaa48ee1ac6cdc53a2fbd
+  languageName: node
+  linkType: hard
+
 "@smithy/util-base64@npm:^4.0.0":
   version: 4.0.0
   resolution: "@smithy/util-base64@npm:4.0.0"
@@ -2537,12 +2712,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-base64@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-base64@npm:4.1.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^4.1.0"
+    "@smithy/util-utf8": "npm:^4.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e2275e4a09c245b8a0c1c6ead4418333d037f6cbc29a01881b56fb5676ad46839058bbdb3f9f357898c8000feccac9344ee66c9c36e17dd321bda84a93f2c36f
+  languageName: node
+  linkType: hard
+
 "@smithy/util-body-length-browser@npm:^4.0.0":
   version: 4.0.0
   resolution: "@smithy/util-body-length-browser@npm:4.0.0"
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/574a10934024a86556e9dcde1a9776170284326c3dfcc034afa128cc5a33c1c8179fca9cfb622ef8be5f2004316cc3f427badccceb943e829105536ec26306d9
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-browser@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-body-length-browser@npm:4.1.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e86c39696dca4ce4b58e393fb85263e31ee046d88fdbd0bd1ee121f5101faca5fc945a7da17432aa39e86c178c80ac183568edb3b7df323f1134172dc36192c6
   languageName: node
   linkType: hard
 
@@ -2575,6 +2770,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-buffer-from@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-buffer-from@npm:4.1.0"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^4.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f19457df277e7125ffbf106c26c70ffbc550956afceede4e2c2eb13a32f6f304f9e3b7a37f4c717df3c5ce97f8b759ee59ceed0e3f649f236bbaf2bfe8f266ef
+  languageName: node
+  linkType: hard
+
 "@smithy/util-config-provider@npm:^4.0.0":
   version: 4.0.0
   resolution: "@smithy/util-config-provider@npm:4.0.0"
@@ -2584,31 +2789,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^4.0.26":
-  version: 4.0.26
-  resolution: "@smithy/util-defaults-mode-browser@npm:4.0.26"
+"@smithy/util-config-provider@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-config-provider@npm:4.1.0"
   dependencies:
-    "@smithy/property-provider": "npm:^4.0.5"
-    "@smithy/smithy-client": "npm:^4.4.10"
-    "@smithy/types": "npm:^4.3.2"
-    bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ba10af21bd302f4705a808673eb3811e36a78c396f7ee93e2dfea5ded7d78470c789d3bc7a23e3d6232b43b7b91f57fbfbd383d11042e6993dc9c49030cbd0ef
+  checksum: 10c0/099add392d9f029dec36d3646af4a63145a13ed8014af11f507bffbdb113fc2bb2bfd71ee157e385320f4c8de4bd48557c98f40878f93022187d3fc3082e6713
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^4.0.26":
-  version: 4.0.26
-  resolution: "@smithy/util-defaults-mode-node@npm:4.0.26"
+"@smithy/util-defaults-mode-browser@npm:^4.0.29":
+  version: 4.1.0
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.1.0"
   dependencies:
-    "@smithy/config-resolver": "npm:^4.1.5"
-    "@smithy/credential-provider-imds": "npm:^4.0.7"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/property-provider": "npm:^4.0.5"
-    "@smithy/smithy-client": "npm:^4.4.10"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/property-provider": "npm:^4.1.0"
+    "@smithy/smithy-client": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.4.0"
+    bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/0a682393db1617681fc132c39d9f01accd5c3c250be457ebb514001d83d34252d404fe6315ee0cc5176e0efc7fdeec64e848299bdefe6113d3c70f81717b665b
+  checksum: 10c0/0732e78f4c4a4cc6dafbad077fbe7314cf35abaaba8c2e1fd7e3eeb3f7ef8860774bc7861d52040b23dbce20facbd7bd6c76b3e46a8b241bd6da82a4c6af48d8
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-node@npm:^4.0.29":
+  version: 4.1.0
+  resolution: "@smithy/util-defaults-mode-node@npm:4.1.0"
+  dependencies:
+    "@smithy/config-resolver": "npm:^4.2.0"
+    "@smithy/credential-provider-imds": "npm:^4.1.0"
+    "@smithy/node-config-provider": "npm:^4.2.0"
+    "@smithy/property-provider": "npm:^4.1.0"
+    "@smithy/smithy-client": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/eed450e20146ae20559c0dd1bc43ea5679b3b34373d9ce9be0795af55c3fb4c085fd84e2fc2f1c1caefcdbfe2e617888502c5badfcaa3ffaadd55896cc6fb1de
   languageName: node
   linkType: hard
 
@@ -2632,6 +2846,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-hex-encoding@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-hex-encoding@npm:4.1.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/eefaa537612afd13e497353a1bd55f3d6f977cdc52360f91fcb3b83b68d6cdd9b9fc16ab82561375b509ed8d5735c47b263c4e64e96471d1662d4c7a8c88449d
+  languageName: node
+  linkType: hard
+
 "@smithy/util-middleware@npm:^4.0.5":
   version: 4.0.5
   resolution: "@smithy/util-middleware@npm:4.0.5"
@@ -2639,6 +2862,16 @@ __metadata:
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/74d9bdbcea4c4aa5304197417c370346b230b7a89893ba0dee0d9771b6ead2628a53fb8a64a3822bf1a30a176ebba2c16ece7003c21880a7ff54be0955356606
+  languageName: node
+  linkType: hard
+
+"@smithy/util-middleware@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-middleware@npm:4.1.0"
+  dependencies:
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/cf2053f43da72d64a43c078e89addd6aeec5027afe5200a839dad532a78f2fac4dbfd6fd8ef7a68d63eb111a252fb7bd558ef79ae007ef6385308566697fda9b
   languageName: node
   linkType: hard
 
@@ -2650,6 +2883,17 @@ __metadata:
     "@smithy/types": "npm:^4.3.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/09c633f59ac51203d917548ceb4caf7678e24c87eea024e97e8d62a918be4a76a1c517622b7e9841cf0e9f50778d6787f62efe6c25ae514ed7068e2323303c72
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-retry@npm:4.1.0"
+  dependencies:
+    "@smithy/service-error-classification": "npm:^4.1.0"
+    "@smithy/types": "npm:^4.4.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b3fd78264e9e5a2f3545affac2f19410bd1afa4b429376e7f60180a8059990ce9f3e35ceed9801ca9d65e5743406ce694a6cede7df92fef105de7612c85a1d56
   languageName: node
   linkType: hard
 
@@ -2669,12 +2913,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-stream@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@smithy/util-stream@npm:4.3.0"
+  dependencies:
+    "@smithy/fetch-http-handler": "npm:^5.2.0"
+    "@smithy/node-http-handler": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.4.0"
+    "@smithy/util-base64": "npm:^4.1.0"
+    "@smithy/util-buffer-from": "npm:^4.1.0"
+    "@smithy/util-hex-encoding": "npm:^4.1.0"
+    "@smithy/util-utf8": "npm:^4.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/97e1577b2804d3e182b6d09dd1c93222b745726fec542648036823fb748c3a420006a401accd4b819099121a5df00b96921c078ce2b3d4f43ade6341541ce3ae
+  languageName: node
+  linkType: hard
+
 "@smithy/util-uri-escape@npm:^4.0.0":
   version: 4.0.0
   resolution: "@smithy/util-uri-escape@npm:4.0.0"
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/23984624060756adba8aa4ab1693fe6b387ee5064d8ec4dfd39bb5908c4ee8b9c3f2dc755da9b07505d8e3ce1338c1867abfa74158931e4728bf3cfcf2c05c3d
+  languageName: node
+  linkType: hard
+
+"@smithy/util-uri-escape@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-uri-escape@npm:4.1.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3ff56036ce93226b05e68d34c1691e51cdd82ac5f2ba635701ba76a36a2b384ce945bfe2d9c4992f7b500387a6fe1de4d5d0825cd7c73fa10165678d443d3acc
   languageName: node
   linkType: hard
 
@@ -2695,6 +2964,16 @@ __metadata:
     "@smithy/util-buffer-from": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/28a5a5372cbf0b3d2e32dd16f79b04c2aec6f704cf13789db922e9686fde38dde0171491cfa4c2c201595d54752a319faaeeed3c325329610887694431e28c98
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-utf8@npm:4.1.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^4.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4331c056b005647701609c42609c3bf0848fdaa01134d891327820c32cfcf7410d8bce1c15d534e5c75af79ea4527c3ca33bccfc104e19a94475fbfe125ecb86
   languageName: node
   linkType: hard
 
@@ -2777,8 +3056,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/file-asset-apis@workspace:packages/file-asset-apis"
   dependencies:
-    "@aws-sdk/client-s3": "npm:~3.873.0"
-    "@smithy/node-http-handler": "npm:~4.1.1"
+    "@aws-sdk/client-s3": "npm:~3.884.0"
+    "@smithy/node-http-handler": "npm:~4.2.0"
     "@terascope/scripts": "npm:~1.21.5"
     "@terascope/utils": "npm:~1.10.2"
     "@types/jest": "npm:~30.0.0"


### PR DESCRIPTION
This PR makes the following changes:

- Updates **@aws-sdk/client-s3** to `v3.884.0`
- Updates **@smithy/node-http-handler** to `v4.2.0`
- Fixes yarn resolution issue where some deps resolve to older version of **@types/smithy** causing type issues

Ref to issue #1344 