### PR TITLE
bundled deps update 2025-09-15

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@terascope/file-asset-apis": "~1.1.2",
-        "@terascope/job-components": "~1.12.2",
+        "@terascope/job-components": "~1.12.3",
         "csvtojson": "~2.0.10",
         "fs-extra": "~11.3.1",
         "json2csv": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/eslint-config": "~1.1.24",
+        "@terascope/eslint-config": "~1.1.25",
         "@terascope/file-asset-apis": "~1.1.2",
-        "@terascope/job-components": "~1.12.2",
-        "@terascope/scripts": "~1.21.5",
+        "@terascope/job-components": "~1.12.3",
+        "@terascope/scripts": "~1.21.6",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
         "@types/json2csv": "~5.0.7",
-        "@types/node": "~24.3.1",
+        "@types/node": "~24.4.0",
         "@types/node-gzip": "~1.1.3",
         "@types/semver": "~7.7.1",
         "eslint": "~9.35.0",
@@ -56,7 +56,7 @@
         "node-gzip": "~1.1.2",
         "node-notifier": "~10.0.1",
         "semver": "~7.7.2",
-        "teraslice-test-harness": "~1.3.7",
+        "teraslice-test-harness": "~1.3.8",
         "ts-jest": "~29.4.1",
         "typescript": "~5.9.2"
     },

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -21,9 +21,9 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "~3.884.0",
-        "@smithy/node-http-handler": "~4.2.0",
-        "@terascope/utils": "~1.10.2",
+        "@aws-sdk/client-s3": "~3.888.0",
+        "@smithy/node-http-handler": "~4.2.1",
+        "@terascope/utils": "~1.10.3",
         "csvtojson": "~2.0.10",
         "fs-extra": "~11.3.1",
         "json2csv": "5.0.7",
@@ -31,7 +31,7 @@
         "node-gzip": "~1.1.2"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.21.5",
+        "@terascope/scripts": "~1.21.6",
         "@types/jest": "~30.0.0",
         "aws-sdk-client-mock": "~4.1.0",
         "jest": "~30.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,495 +97,496 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:~3.884.0":
-  version: 3.884.0
-  resolution: "@aws-sdk/client-s3@npm:3.884.0"
+"@aws-sdk/client-s3@npm:~3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/client-s3@npm:3.888.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:5.2.0"
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/credential-provider-node": "npm:3.883.0"
-    "@aws-sdk/middleware-bucket-endpoint": "npm:3.873.0"
-    "@aws-sdk/middleware-expect-continue": "npm:3.873.0"
-    "@aws-sdk/middleware-flexible-checksums": "npm:3.883.0"
-    "@aws-sdk/middleware-host-header": "npm:3.873.0"
-    "@aws-sdk/middleware-location-constraint": "npm:3.873.0"
-    "@aws-sdk/middleware-logger": "npm:3.876.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.873.0"
-    "@aws-sdk/middleware-sdk-s3": "npm:3.883.0"
-    "@aws-sdk/middleware-ssec": "npm:3.873.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.883.0"
-    "@aws-sdk/region-config-resolver": "npm:3.873.0"
-    "@aws-sdk/signature-v4-multi-region": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/util-endpoints": "npm:3.879.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.873.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.883.0"
-    "@aws-sdk/xml-builder": "npm:3.873.0"
-    "@smithy/config-resolver": "npm:^4.1.5"
-    "@smithy/core": "npm:^3.9.2"
-    "@smithy/eventstream-serde-browser": "npm:^4.0.5"
-    "@smithy/eventstream-serde-config-resolver": "npm:^4.1.3"
-    "@smithy/eventstream-serde-node": "npm:^4.0.5"
-    "@smithy/fetch-http-handler": "npm:^5.1.1"
-    "@smithy/hash-blob-browser": "npm:^4.0.5"
-    "@smithy/hash-node": "npm:^4.0.5"
-    "@smithy/hash-stream-node": "npm:^4.0.5"
-    "@smithy/invalid-dependency": "npm:^4.0.5"
-    "@smithy/md5-js": "npm:^4.0.5"
-    "@smithy/middleware-content-length": "npm:^4.0.5"
-    "@smithy/middleware-endpoint": "npm:^4.1.21"
-    "@smithy/middleware-retry": "npm:^4.1.22"
-    "@smithy/middleware-serde": "npm:^4.0.9"
-    "@smithy/middleware-stack": "npm:^4.0.5"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/node-http-handler": "npm:^4.1.1"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.5.2"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/url-parser": "npm:^4.0.5"
-    "@smithy/util-base64": "npm:^4.0.0"
-    "@smithy/util-body-length-browser": "npm:^4.0.0"
-    "@smithy/util-body-length-node": "npm:^4.0.0"
-    "@smithy/util-defaults-mode-browser": "npm:^4.0.29"
-    "@smithy/util-defaults-mode-node": "npm:^4.0.29"
-    "@smithy/util-endpoints": "npm:^3.0.7"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    "@smithy/util-retry": "npm:^4.0.7"
-    "@smithy/util-stream": "npm:^4.2.4"
-    "@smithy/util-utf8": "npm:^4.0.0"
-    "@smithy/util-waiter": "npm:^4.0.7"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/credential-provider-node": "npm:3.888.0"
+    "@aws-sdk/middleware-bucket-endpoint": "npm:3.887.0"
+    "@aws-sdk/middleware-expect-continue": "npm:3.887.0"
+    "@aws-sdk/middleware-flexible-checksums": "npm:3.888.0"
+    "@aws-sdk/middleware-host-header": "npm:3.887.0"
+    "@aws-sdk/middleware-location-constraint": "npm:3.887.0"
+    "@aws-sdk/middleware-logger": "npm:3.887.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.887.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.888.0"
+    "@aws-sdk/middleware-ssec": "npm:3.887.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.888.0"
+    "@aws-sdk/region-config-resolver": "npm:3.887.0"
+    "@aws-sdk/signature-v4-multi-region": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@aws-sdk/util-endpoints": "npm:3.887.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.887.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.888.0"
+    "@aws-sdk/xml-builder": "npm:3.887.0"
+    "@smithy/config-resolver": "npm:^4.2.1"
+    "@smithy/core": "npm:^3.11.0"
+    "@smithy/eventstream-serde-browser": "npm:^4.1.1"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.2.1"
+    "@smithy/eventstream-serde-node": "npm:^4.1.1"
+    "@smithy/fetch-http-handler": "npm:^5.2.1"
+    "@smithy/hash-blob-browser": "npm:^4.1.1"
+    "@smithy/hash-node": "npm:^4.1.1"
+    "@smithy/hash-stream-node": "npm:^4.1.1"
+    "@smithy/invalid-dependency": "npm:^4.1.1"
+    "@smithy/md5-js": "npm:^4.1.1"
+    "@smithy/middleware-content-length": "npm:^4.1.1"
+    "@smithy/middleware-endpoint": "npm:^4.2.1"
+    "@smithy/middleware-retry": "npm:^4.2.1"
+    "@smithy/middleware-serde": "npm:^4.1.1"
+    "@smithy/middleware-stack": "npm:^4.1.1"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/node-http-handler": "npm:^4.2.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/url-parser": "npm:^4.1.1"
+    "@smithy/util-base64": "npm:^4.1.0"
+    "@smithy/util-body-length-browser": "npm:^4.1.0"
+    "@smithy/util-body-length-node": "npm:^4.1.0"
+    "@smithy/util-defaults-mode-browser": "npm:^4.1.1"
+    "@smithy/util-defaults-mode-node": "npm:^4.1.1"
+    "@smithy/util-endpoints": "npm:^3.1.1"
+    "@smithy/util-middleware": "npm:^4.1.1"
+    "@smithy/util-retry": "npm:^4.1.1"
+    "@smithy/util-stream": "npm:^4.3.1"
+    "@smithy/util-utf8": "npm:^4.1.0"
+    "@smithy/util-waiter": "npm:^4.1.1"
     "@types/uuid": "npm:^9.0.1"
     tslib: "npm:^2.6.2"
     uuid: "npm:^9.0.1"
-  checksum: 10c0/6a593ce77679b118e9d17ad62d2702b97deb2e196fb6f1734e83307856db370b5d94390e9bd54860c176b31334413d963ed5920403fab199dbd9f147ff479925
+  checksum: 10c0/62e620bfeb496b6e8be2682f5b8a806c6b302b82b0e0c65232729ac342f113b2fc9c3982a247fa5f272dfa223e661380f9461d76306aad509152cca666dc3f1d
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/client-sso@npm:3.883.0"
+"@aws-sdk/client-sso@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/client-sso@npm:3.888.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/middleware-host-header": "npm:3.873.0"
-    "@aws-sdk/middleware-logger": "npm:3.876.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.873.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.883.0"
-    "@aws-sdk/region-config-resolver": "npm:3.873.0"
-    "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/util-endpoints": "npm:3.879.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.873.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.883.0"
-    "@smithy/config-resolver": "npm:^4.1.5"
-    "@smithy/core": "npm:^3.9.2"
-    "@smithy/fetch-http-handler": "npm:^5.1.1"
-    "@smithy/hash-node": "npm:^4.0.5"
-    "@smithy/invalid-dependency": "npm:^4.0.5"
-    "@smithy/middleware-content-length": "npm:^4.0.5"
-    "@smithy/middleware-endpoint": "npm:^4.1.21"
-    "@smithy/middleware-retry": "npm:^4.1.22"
-    "@smithy/middleware-serde": "npm:^4.0.9"
-    "@smithy/middleware-stack": "npm:^4.0.5"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/node-http-handler": "npm:^4.1.1"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.5.2"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/url-parser": "npm:^4.0.5"
-    "@smithy/util-base64": "npm:^4.0.0"
-    "@smithy/util-body-length-browser": "npm:^4.0.0"
-    "@smithy/util-body-length-node": "npm:^4.0.0"
-    "@smithy/util-defaults-mode-browser": "npm:^4.0.29"
-    "@smithy/util-defaults-mode-node": "npm:^4.0.29"
-    "@smithy/util-endpoints": "npm:^3.0.7"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    "@smithy/util-retry": "npm:^4.0.7"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/middleware-host-header": "npm:3.887.0"
+    "@aws-sdk/middleware-logger": "npm:3.887.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.887.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.888.0"
+    "@aws-sdk/region-config-resolver": "npm:3.887.0"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@aws-sdk/util-endpoints": "npm:3.887.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.887.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.888.0"
+    "@smithy/config-resolver": "npm:^4.2.1"
+    "@smithy/core": "npm:^3.11.0"
+    "@smithy/fetch-http-handler": "npm:^5.2.1"
+    "@smithy/hash-node": "npm:^4.1.1"
+    "@smithy/invalid-dependency": "npm:^4.1.1"
+    "@smithy/middleware-content-length": "npm:^4.1.1"
+    "@smithy/middleware-endpoint": "npm:^4.2.1"
+    "@smithy/middleware-retry": "npm:^4.2.1"
+    "@smithy/middleware-serde": "npm:^4.1.1"
+    "@smithy/middleware-stack": "npm:^4.1.1"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/node-http-handler": "npm:^4.2.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/url-parser": "npm:^4.1.1"
+    "@smithy/util-base64": "npm:^4.1.0"
+    "@smithy/util-body-length-browser": "npm:^4.1.0"
+    "@smithy/util-body-length-node": "npm:^4.1.0"
+    "@smithy/util-defaults-mode-browser": "npm:^4.1.1"
+    "@smithy/util-defaults-mode-node": "npm:^4.1.1"
+    "@smithy/util-endpoints": "npm:^3.1.1"
+    "@smithy/util-middleware": "npm:^4.1.1"
+    "@smithy/util-retry": "npm:^4.1.1"
+    "@smithy/util-utf8": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/972315c4d0560af7a0d9ca7421b8820306c8f4b4a4359e68352a63af3e50f4160a861b7ffb4f3e26f4cf9f9818a4d4f47f9daeee4f97b7bb24e27b568b79226a
+  checksum: 10c0/8798cad059c5f29baf191d240c9b49a2dd7dce855e151de2e3532b8c8cff7b717fdebc93689ec37759baf89e8cfdaa6029803206cba4cfb59eb7a2848873ac58
   languageName: node
   linkType: hard
 
-"@aws-sdk/core@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/core@npm:3.883.0"
+"@aws-sdk/core@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/core@npm:3.888.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/xml-builder": "npm:3.873.0"
-    "@smithy/core": "npm:^3.9.2"
-    "@smithy/node-config-provider": "npm:^4.1.4"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@aws-sdk/xml-builder": "npm:3.887.0"
+    "@smithy/core": "npm:^3.11.0"
+    "@smithy/node-config-provider": "npm:^4.2.1"
     "@smithy/property-provider": "npm:^4.0.5"
-    "@smithy/protocol-http": "npm:^5.1.3"
+    "@smithy/protocol-http": "npm:^5.2.1"
     "@smithy/signature-v4": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.5.2"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-base64": "npm:^4.0.0"
-    "@smithy/util-body-length-browser": "npm:^4.0.0"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-base64": "npm:^4.1.0"
+    "@smithy/util-body-length-browser": "npm:^4.1.0"
+    "@smithy/util-middleware": "npm:^4.1.1"
+    "@smithy/util-utf8": "npm:^4.1.0"
     fast-xml-parser: "npm:5.2.5"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c3416b83df0f9ac3c0ac05deaea0d9616bc72d189327fd2a6249c6b976f6d5c36a3fa9f9b27bc881f5be48efddf518d8d79f3677f482ad10080c4edd58a6e9c4
+  checksum: 10c0/48e904a79b85cf5bceeb88b73c632c140750e6c9643c78bc38229168d7609207f3bc8c98801783a2a0457fc6da148f5ba96226201d9bda12df6fa1b11d8b68dd
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.883.0"
+"@aws-sdk/credential-provider-env@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.888.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@smithy/property-provider": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/be028db70cf9d24857aee5c336af778c99cfcfef3493ce905b041e60b637aedd2ec164757fe9ef3a01d292146cb416ef4a5a1468ab42f05b5b77c5fc7d55d36e
+  checksum: 10c0/09c4fb216031ba9695a0966692bacf8bce6e65fa52454293bcf87533cf5c872e5f322922fd72bfa180a69ab53df33d58aafd8aa93ddb419c83b12f020bf0c78f
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-http@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/credential-provider-http@npm:3.883.0"
+"@aws-sdk/credential-provider-http@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.888.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/fetch-http-handler": "npm:^5.1.1"
-    "@smithy/node-http-handler": "npm:^4.1.1"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/fetch-http-handler": "npm:^5.2.1"
+    "@smithy/node-http-handler": "npm:^4.2.1"
     "@smithy/property-provider": "npm:^4.0.5"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.5.2"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-stream": "npm:^4.2.4"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-stream": "npm:^4.3.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/5487b9691e2775d5a933940571153a8ce9f639d1cf19c92ae263ea97033d2c8158b97be41cba58a6b59b1405333c00c50e204a192faad9d5231b2f633d28a444
+  checksum: 10c0/b8f66d2b80b1118ac047c54c2d6607dc9e042c904080f52926ae8a38e10b9571837e433be94a763cfb560dd9011e5078bdf15cd06ef5074d6dd2303819a445ab
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.883.0"
+"@aws-sdk/credential-provider-ini@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.888.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/credential-provider-env": "npm:3.883.0"
-    "@aws-sdk/credential-provider-http": "npm:3.883.0"
-    "@aws-sdk/credential-provider-process": "npm:3.883.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.883.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.883.0"
-    "@aws-sdk/nested-clients": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/credential-provider-env": "npm:3.888.0"
+    "@aws-sdk/credential-provider-http": "npm:3.888.0"
+    "@aws-sdk/credential-provider-process": "npm:3.888.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.888.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.888.0"
+    "@aws-sdk/nested-clients": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@smithy/credential-provider-imds": "npm:^4.0.7"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d642df1224842c9f882406b7de0059e2efd6ab44c7994ed49bdc2aa0450b0dccbc561998df6fa3f9d1bee48edc4ad1bd985f56ab3eb3672db574a3ffe6735a9d
+  checksum: 10c0/89eeba91cec2f083519dc82c3ecace3ff338326964ff67a647b542f762bf629c0f25d9cce5d978e207c64629e2456ba1c099688bcd9058346ae8f3024e6e47a8
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.883.0"
+"@aws-sdk/credential-provider-node@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.888.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.883.0"
-    "@aws-sdk/credential-provider-http": "npm:3.883.0"
-    "@aws-sdk/credential-provider-ini": "npm:3.883.0"
-    "@aws-sdk/credential-provider-process": "npm:3.883.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.883.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/credential-provider-env": "npm:3.888.0"
+    "@aws-sdk/credential-provider-http": "npm:3.888.0"
+    "@aws-sdk/credential-provider-ini": "npm:3.888.0"
+    "@aws-sdk/credential-provider-process": "npm:3.888.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.888.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@smithy/credential-provider-imds": "npm:^4.0.7"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7b8a495bf4c55766a53c79899055ea1051b5823e02ea36fea59774e24d92d8446a68386a2ea04dcec769e8ea0526da545e5de5eb8e9b537ac124b20d1ceff798
+  checksum: 10c0/a920c4c21bfc084db9ea02b32220a784f59d50cb1126ca9197c3c1b44c13cbe3638c0fa74fe384f06965c4c4e0b63eed2c2add371b55c44807a9cd5a3edda981
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.883.0"
+"@aws-sdk/credential-provider-process@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.888.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9d6d89059dfd00172d492cd77f7b21c29c14ccd2a877ca2e141c2a5f58a57a33bcb588cfa9d5993f599b80be7e39313b37fa9ac81f646eedd299fbafc8202a8c
+  checksum: 10c0/117d6e2cb50bb064a3cf7b0f051d554981d7a4db514828d31ed9a44f5c4a0b83eed639a7bacaf64fdbe2e7bca705c71c590fa52e0d31ff5546a4745caaa0906c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.883.0"
+"@aws-sdk/credential-provider-sso@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.888.0"
   dependencies:
-    "@aws-sdk/client-sso": "npm:3.883.0"
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/token-providers": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/client-sso": "npm:3.888.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/token-providers": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/23557b036221200407a7b446f40511178c55b2f6ef75c3c94f5ab16e8d119e49fd8ad7fba969d45fa24cdcf1f30f1e0ccf0bb95573e860744fc8bd9af9a1055e
+  checksum: 10c0/2c5df695b2d4a7e2561e7fdba2ff456941e5fdb2bbf788d2c59f31fdc6ddab5f897ccc9e469c16be0688cd9edc3db0a6b010036a0d3d824c495c668a4238b312
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.883.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.888.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/nested-clients": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/nested-clients": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@smithy/property-provider": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/55fcfd5a2bb9e6762b26c3c37da0b48b8677dc60067f97ca0b941420e23ac6cce4e2bd577282ce3116a296f9cc9cd6af846cc50486f0bc8f1898b77f9a37f7e5
+  checksum: 10c0/1508729df48d0426b661652ed0e333eacb3ec9732d64a92e95a325e30cdc82cdf56cc03713ea090c2648078e79188077865ba7093f00e8354f7b6b15ee96cf4e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.873.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@aws-sdk/util-arn-parser": "npm:3.873.0"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
     "@smithy/util-config-provider": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/08b8c7204ab12f9ee877d2cdd1f8422bdf253731fcb1331c880f4d69872c15da0e076e996739e3d8ebb33f6da76da0d3ea42f4eca95955a7c5a004ee023ab284
+  checksum: 10c0/bb93a2a0d0695f579bde9547a72814c6434d0e3979dee7522320336771a46751474778acb78590ccadaac2349adc0a9d0f4b1dcb21db38f09ce6051b003c87ed
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.873.0"
+"@aws-sdk/middleware-expect-continue@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/738e1f33b47f91dc5b3cc8a2564e47d72b9e3add99e9336128545303fa01cf96c4b6a75bee5e477e6369fbe2ae4c7449aa754a246d5c0027c51c9e1bd7482bec
+  checksum: 10c0/c64b397ddde2597019396c37b1103413490424149cf1b09a5974b728297ad1e8ff37d89a9f75e493e922bd01f001d6b68dff171dd348f12fa37b662884c731be
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-flexible-checksums@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.883.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.888.0"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
     "@aws-crypto/crc32c": "npm:5.2.0"
     "@aws-crypto/util": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@smithy/is-array-buffer": "npm:^4.0.0"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    "@smithy/util-stream": "npm:^4.2.4"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-middleware": "npm:^4.1.1"
+    "@smithy/util-stream": "npm:^4.3.1"
+    "@smithy/util-utf8": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c5ab881cb3e30dc8a003f131be60634375981cba6b55c1098f186484aa2779c8991af8279bfcbf4cfe688294cef09489f8924516f3d0a271efb5fd56496520b3
+  checksum: 10c0/50af4401046a824d70d9b7deb526658e672e65c7b6b5c29774633ddd70ebdb9ccebae7cd3c09c4af77f2b898603750303c348580bab957c8496f8e44de9e386b
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.873.0"
+"@aws-sdk/middleware-host-header@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/177f42c4342666ba8270a3a0f5de16e713b7245b8b5435f1b4863d46cbad9ea8930d23d9731d79ffc0b960be7f70a96693fa0b524a2dd24ca61d1ce8873c9b55
+  checksum: 10c0/2fcd88f9e4bd06a37f7e6d53cd86d8e031decedaf036e4d76f044b034808042b6713af88c86d4d9d981c41ac6c52c6d3d420644283a56b58d0243b59b465a17a
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-location-constraint@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.873.0"
+"@aws-sdk/middleware-location-constraint@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a76c3df86ba5ac393c9cfd4c4ff9db8b486ea299b5f27f73e12b8d73700bddd87b0c826b380c3ba02208f2e1f98aa7e0086109143ba984f2f96e0bf0cbc64d25
+  checksum: 10c0/c8b70e145c054534be4a409608aa9821e709bd726d60dd642298b2a008b52264215783b15ded513289d64217a512777f3a11046eb9222f37cc24c0b6d0ab63c7
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.876.0":
-  version: 3.876.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.876.0"
+"@aws-sdk/middleware-logger@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8a4b31102579bbdabc22f982277239535627e658fce8cff32df4032c510ec944ce4ffef73ae6cd948b918f87809133c6e3e3f7fdd60bd6feec89f4cbab4300c8
+  checksum: 10c0/025e37a0945fe3c34ac49c34d420b5b66d3258d425039fcec150a0180e6f5cce744017256dfdbb773d860aaaf6f541de90e623bc0cd84ef3a99c0313d7d941b9
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.873.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@aws/lambda-invoke-store": "npm:^0.0.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ce8b10a9da07faf41246c581d342ac3a8e4373bd8c1e07e131573575fed8d6d379e15b4d8f0efebd84936bf4fc800ae7719e36b50931bcf4df2ac547bde31f61
+  checksum: 10c0/a10fdf1ed626f7bcd8b8cc91145723611be8d5fc8d9127d8be6fe90bb0d4164914e74bc5946baad48bfd09352ac0810204f7be69df450da9c71391fda853d191
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.883.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.888.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@aws-sdk/util-arn-parser": "npm:3.873.0"
-    "@smithy/core": "npm:^3.9.2"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/protocol-http": "npm:^5.1.3"
+    "@smithy/core": "npm:^3.11.0"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
     "@smithy/signature-v4": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.5.2"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
     "@smithy/util-config-provider": "npm:^4.0.0"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    "@smithy/util-stream": "npm:^4.2.4"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@smithy/util-middleware": "npm:^4.1.1"
+    "@smithy/util-stream": "npm:^4.3.1"
+    "@smithy/util-utf8": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8ad3003b1ebc462be49ead4c687b78d9aee863ecc28cc4876db00762815c5e8cc1e1bc6e39faee6644a06b24325536fd8a5e1195bf93b0336fb6b641f821aabb
+  checksum: 10c0/1758ede7e6f539593c57dd8056c2dd1d14a90f7f0ac6bbcce8169f48f48efa3606c7bec4a40e72c288ecb251fdf5283a500961136da90803eb0729b1378b8337
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-ssec@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.873.0"
+"@aws-sdk/middleware-ssec@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/87f0ecfff55b922c61016b802c5c41a82222beb072b66dee0bc9bb422a1297c92444444a25b3cf4ea416a1be3cd85401beebc929e6661473f778846685b95c35
+  checksum: 10c0/182d240d172719c1098f78af73835a9b4e649a336dfebf91078506a67f8438a84510d1f7836888d12db95626a824e5dd64991f7e489673e90a59a4191262067d
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.883.0"
+"@aws-sdk/middleware-user-agent@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.888.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/util-endpoints": "npm:3.879.0"
-    "@smithy/core": "npm:^3.9.2"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@aws-sdk/util-endpoints": "npm:3.887.0"
+    "@smithy/core": "npm:^3.11.0"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/dfb27c854a35f74258f3a8b2fed2250a155496956e6cc2c664bdc444c92fc085c26573837e83e02735adc06a1815f3faa73195bc125bf4563f1b7c91081e6870
+  checksum: 10c0/b11b4ab11cfaeb3a788de2a55c780bac0786684da371c662ace33641fabd04397f4bd88dd6958fcff8eab60422733c47781e90e79a7882f7f5a0761340ee093a
   languageName: node
   linkType: hard
 
-"@aws-sdk/nested-clients@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/nested-clients@npm:3.883.0"
+"@aws-sdk/nested-clients@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/nested-clients@npm:3.888.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/middleware-host-header": "npm:3.873.0"
-    "@aws-sdk/middleware-logger": "npm:3.876.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.873.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.883.0"
-    "@aws-sdk/region-config-resolver": "npm:3.873.0"
-    "@aws-sdk/types": "npm:3.862.0"
-    "@aws-sdk/util-endpoints": "npm:3.879.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.873.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.883.0"
-    "@smithy/config-resolver": "npm:^4.1.5"
-    "@smithy/core": "npm:^3.9.2"
-    "@smithy/fetch-http-handler": "npm:^5.1.1"
-    "@smithy/hash-node": "npm:^4.0.5"
-    "@smithy/invalid-dependency": "npm:^4.0.5"
-    "@smithy/middleware-content-length": "npm:^4.0.5"
-    "@smithy/middleware-endpoint": "npm:^4.1.21"
-    "@smithy/middleware-retry": "npm:^4.1.22"
-    "@smithy/middleware-serde": "npm:^4.0.9"
-    "@smithy/middleware-stack": "npm:^4.0.5"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/node-http-handler": "npm:^4.1.1"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/smithy-client": "npm:^4.5.2"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/url-parser": "npm:^4.0.5"
-    "@smithy/util-base64": "npm:^4.0.0"
-    "@smithy/util-body-length-browser": "npm:^4.0.0"
-    "@smithy/util-body-length-node": "npm:^4.0.0"
-    "@smithy/util-defaults-mode-browser": "npm:^4.0.29"
-    "@smithy/util-defaults-mode-node": "npm:^4.0.29"
-    "@smithy/util-endpoints": "npm:^3.0.7"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    "@smithy/util-retry": "npm:^4.0.7"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/middleware-host-header": "npm:3.887.0"
+    "@aws-sdk/middleware-logger": "npm:3.887.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.887.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.888.0"
+    "@aws-sdk/region-config-resolver": "npm:3.887.0"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@aws-sdk/util-endpoints": "npm:3.887.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.887.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.888.0"
+    "@smithy/config-resolver": "npm:^4.2.1"
+    "@smithy/core": "npm:^3.11.0"
+    "@smithy/fetch-http-handler": "npm:^5.2.1"
+    "@smithy/hash-node": "npm:^4.1.1"
+    "@smithy/invalid-dependency": "npm:^4.1.1"
+    "@smithy/middleware-content-length": "npm:^4.1.1"
+    "@smithy/middleware-endpoint": "npm:^4.2.1"
+    "@smithy/middleware-retry": "npm:^4.2.1"
+    "@smithy/middleware-serde": "npm:^4.1.1"
+    "@smithy/middleware-stack": "npm:^4.1.1"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/node-http-handler": "npm:^4.2.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/url-parser": "npm:^4.1.1"
+    "@smithy/util-base64": "npm:^4.1.0"
+    "@smithy/util-body-length-browser": "npm:^4.1.0"
+    "@smithy/util-body-length-node": "npm:^4.1.0"
+    "@smithy/util-defaults-mode-browser": "npm:^4.1.1"
+    "@smithy/util-defaults-mode-node": "npm:^4.1.1"
+    "@smithy/util-endpoints": "npm:^3.1.1"
+    "@smithy/util-middleware": "npm:^4.1.1"
+    "@smithy/util-retry": "npm:^4.1.1"
+    "@smithy/util-utf8": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e894c9dd161d0bc5c069803ef4178991f4ccbc8f46d2172425898923a1a0a8c04546c80a56223f2f5c6f18173b9f557d78f6b55e39a1cfab5cc578425706b819
+  checksum: 10c0/c7ccdaccbcf9daa73b98776913655a0a453b5dfb68c5797e4e0f244dc04ea8777d80e74b92459844fa1bedb7bde33616b9893d36b6c6140e9e4c1108a1a7126f
   languageName: node
   linkType: hard
 
-"@aws-sdk/region-config-resolver@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/region-config-resolver@npm:3.873.0"
+"@aws-sdk/region-config-resolver@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/types": "npm:^4.5.0"
     "@smithy/util-config-provider": "npm:^4.0.0"
-    "@smithy/util-middleware": "npm:^4.0.5"
+    "@smithy/util-middleware": "npm:^4.1.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/5d2141beaafcc2cf56fe8c92efb176f773de1fbaaac9645fb26ca4478648c0bc440b73bbe8a9837f1843d66bdb513d1ad6e649ffbbd03dc3dae9eeb06c318622
+  checksum: 10c0/4dbd6b7e312b8930578b3d50e6104bd91e93d11e6ecc6921e5e5176e5eb320751c575e7e3f0a8916ce57a4367c3073ebc1886013c1767fa2eae46fc36e37ccb6
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.883.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.888.0"
   dependencies:
-    "@aws-sdk/middleware-sdk-s3": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/protocol-http": "npm:^5.1.3"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/protocol-http": "npm:^5.2.1"
     "@smithy/signature-v4": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c426415461ca6aee0ad5fd54d72a2cdd119ae01a651fd2d9222c6bcef5fcecb87a9ce5d6e81581665ccb81d10955e07c4d47b65545f1792c03c646c3c629ba4d
+  checksum: 10c0/67ca1fa741d3900cb9d6c8672e1ad1d7bfdb46aea195302badf04cfd4ff4d6cfd7d55b7ac65c1086b5d5d4fe4ecfefb6f7bc33fc0b882c631d3adf577d273eb9
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/token-providers@npm:3.883.0"
+"@aws-sdk/token-providers@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/token-providers@npm:3.888.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.883.0"
-    "@aws-sdk/nested-clients": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
+    "@aws-sdk/core": "npm:3.888.0"
+    "@aws-sdk/nested-clients": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
     "@smithy/property-provider": "npm:^4.0.5"
     "@smithy/shared-ini-file-loader": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7f329c4c0fb23f2d8b18e26b82f142655163c6ecc93014730cb465040d3c8aa9d63fb877c936cd20684c3d1d8eee87bbcfb515fda146a79f37a28d7bb64ac0df
+  checksum: 10c0/3f303400d2fb5a2e015f375a08f4b0295565dea51ec7be7a6a10ca3264e00727781936e12025093349d0d49f0c9caa4da70407827c5c4dc635501ddd69841d5e
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.862.0":
-  version: 3.862.0
-  resolution: "@aws-sdk/types@npm:3.862.0"
+"@aws-sdk/types@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/types@npm:3.887.0"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d8e13eadde27c29e39d8effa861a3dc8ef43fba6ecb9772e3461619a76897873c8d4355be89aa5090294d1f17e1a6697834f0bbf6a7f73902a77fe00b1fbe5c2
+  checksum: 10c0/862ad368a8692cf75b0e44e96b2fe96c0e145f3c40bbb4a6fe07de1f5935722f0ecdc983fdf09789527a2555392a3cac08372d9a7cdec5f15849508083104413
   languageName: node
   linkType: hard
 
@@ -608,16 +609,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-endpoints@npm:3.879.0":
-  version: 3.879.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.879.0"
+"@aws-sdk/util-endpoints@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/url-parser": "npm:^4.0.5"
-    "@smithy/util-endpoints": "npm:^3.0.7"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/url-parser": "npm:^4.1.1"
+    "@smithy/util-endpoints": "npm:^3.1.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/abf709bbdaf26f5920f41e105a153a959e0451b88c047957181b7ad834b1b5914d72728a89142a3921c389485a173537a8e0505ff4b308276b5334cbbd7fd60a
+  checksum: 10c0/679ff558bf480abf89e193fa0dcb92ffe96ad343ed8f6c0fca4aefc238f4f61e28aabdfff3a62b1d39c68a5d74ddb6c2b60eb1349e36c8cfec7fd2bb21abb8c2
   languageName: node
   linkType: hard
 
@@ -630,43 +631,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.873.0"
+"@aws-sdk/util-user-agent-browser@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.887.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/types": "npm:^4.5.0"
     bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a65177d5b27632ebeb4e922ee3a7ab1bce06d8120a9ac33343900125be67498837f0df8495008df6144ef7b687c095477016dba54d40be11397b6a418a4f81ef
+  checksum: 10c0/f48410fbdb2f986e798072a7fb55ee0780fe90c57c35f8ad22bd9127914d911ea63b6d43b62ebb81edfb8b82ec5eed1f6bc93135bc55fad294f7e5b638d20f61
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.883.0":
-  version: 3.883.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.883.0"
+"@aws-sdk/util-user-agent-node@npm:3.888.0":
+  version: 3.888.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.888.0"
   dependencies:
-    "@aws-sdk/middleware-user-agent": "npm:3.883.0"
-    "@aws-sdk/types": "npm:3.862.0"
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/types": "npm:^4.3.2"
+    "@aws-sdk/middleware-user-agent": "npm:3.888.0"
+    "@aws-sdk/types": "npm:3.887.0"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 10c0/440ba1130df97f0a4899e0d9245993ce579cb54edad427534c90bb6e37c2b3aa48951527bb07598f0505c8117f282c984ce7e2ec4270a7be07f6f9720c06eafd
+  checksum: 10c0/bf33a98b75dbd8d4093eb191190df391cfa4dfff3a1ae6c48a3d51de68c144ba892b240b7c37c16d98deb60231e4e2c005f2df13a7e1df0c7f8df504aa07d4c5
   languageName: node
   linkType: hard
 
-"@aws-sdk/xml-builder@npm:3.873.0":
-  version: 3.873.0
-  resolution: "@aws-sdk/xml-builder@npm:3.873.0"
+"@aws-sdk/xml-builder@npm:3.887.0":
+  version: 3.887.0
+  resolution: "@aws-sdk/xml-builder@npm:3.887.0"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/f58d49c1bbee2fb8a225b23ff7c26e84264df657d55cf7ca204f07f583603cbb75be356a5ef576810f9a1fddfe133d556ead0a39349cdb94e28bcaae6c279128
+  checksum: 10c0/a8ec9b57934cba380ee72f7d5bab5305e61ffd12f8eed5957d062db0983de58a8a9f62f4979c036eccad4b74d8cf9267e8e6d21601f2dc85cc1db54a5eb17ce9
+  languageName: node
+  linkType: hard
+
+"@aws/lambda-invoke-store@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@aws/lambda-invoke-store@npm:0.0.1"
+  checksum: 10c0/0bbf3060014a462177fb743e132e9b106a6743ad9cd905df4bd26e9ca8bfe2cc90473b03a79938fa908934e45e43f366f57af56a697991abda71d9ac92f5018f
   languageName: node
   linkType: hard
 
@@ -1183,17 +1191,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "@eslint-community/eslint-utils@npm:4.7.0"
-  dependencies:
-    eslint-visitor-keys: "npm:^3.4.3"
-  peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10c0/c0f4f2bd73b7b7a9de74b716a664873d08ab71ab439e51befe77d61915af41a81ecec93b408778b3a7856185244c34c2c8ee28912072ec14def84ba2dec70adf
-  languageName: node
-  linkType: hard
-
 "@eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
@@ -1202,6 +1199,17 @@ __metadata:
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
   checksum: 10c0/7e559c4ce59cd3a06b1b5a517b593912e680a7f981ae7affab0d01d709e99cd5647019be8fafa38c350305bc32f1f7d42c7073edde2ab536c745e365f37b607e
+  languageName: node
+  linkType: hard
+
+"@eslint-community/eslint-utils@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@eslint-community/eslint-utils@npm:4.7.0"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10c0/c0f4f2bd73b7b7a9de74b716a664873d08ab71ab439e51befe77d61915af41a81ecec93b408778b3a7856185244c34c2c8ee28912072ec14def84ba2dec70adf
   languageName: node
   linkType: hard
 
@@ -1279,14 +1287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.34.0, @eslint/js@npm:~9.34.0":
-  version: 9.34.0
-  resolution: "@eslint/js@npm:9.34.0"
-  checksum: 10c0/53f1bfd2a374683d9382a6850354555f6e89a88416c34a5d34e9fbbaf717e97c2b06300e8f93e5eddba8bda8951ccab7f93a680e56ded1a3d21d526019e69bab
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.35.0":
+"@eslint/js@npm:9.35.0, @eslint/js@npm:~9.35.0":
   version: 9.35.0
   resolution: "@eslint/js@npm:9.35.0"
   checksum: 10c0/d40fe38724bc76c085c0b753cdf937fa35c0d6807ae76b2632e3f5f66c3040c91adcf1aff2ce70b4f45752e60629fadc415eeec9af3be3c274bae1cac54b9840
@@ -2099,87 +2100,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/abort-controller@npm:4.0.5"
+"@smithy/abort-controller@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/abort-controller@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/0a16d5571f5aa3d6d43465ce1060263a92c6eba011cf448adaeafb940121981ecb26fabb0185745520cace9dfd9aebe6879930ff3b55c8f1b42ac6a337070f20
+  checksum: 10c0/f50ee8e76dab55df7af7247c5dac88209702b9e0a775a5d98472d67c607b6f624c3789ac75974c8b6fa452e1a4f9f72e5749dbea5b57f14d7ca137929e36f0ee
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^4.1.0":
+"@smithy/chunked-blob-reader-native@npm:^4.1.0":
   version: 4.1.0
-  resolution: "@smithy/abort-controller@npm:4.1.0"
+  resolution: "@smithy/chunked-blob-reader-native@npm:4.1.0"
   dependencies:
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/util-base64": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/fd70202a85b9821e1ba1b326c16e8d0d7a5662b9a0c208b255c03f601abe9ec7d9024c27acaa3b70a3c1c0aec4153e9dab90df526f42a298ebc1dd8b3519c2a1
+  checksum: 10c0/1b6805ac870c2138c471997b80a75967eb7226cc86dc8550797446b4106e22fd078c4717b4acf5deda9fba284eac7738b4c7ed749a5199e44c1d482f35c7d3b8
   languageName: node
   linkType: hard
 
-"@smithy/chunked-blob-reader-native@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/chunked-blob-reader-native@npm:4.0.0"
+"@smithy/chunked-blob-reader@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@smithy/chunked-blob-reader@npm:5.1.0"
   dependencies:
-    "@smithy/util-base64": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4387f4e8841f20c1c4e689078141de7e6f239e7883be3a02810a023aa30939b15576ee00227b991972d2c5a2f3b6152bcaeca0975c9fa8d3669354c647bd532a
+  checksum: 10c0/28f2ac63b2c019f605d7669fb9dc2a77e3ab54460a7c23fa3eaa64fa80d465e971905a80717a6260b88941f2acca556128984d914cd728fa34bcb2bd2826e7b8
   languageName: node
   linkType: hard
 
-"@smithy/chunked-blob-reader@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@smithy/chunked-blob-reader@npm:5.0.0"
+"@smithy/config-resolver@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@smithy/config-resolver@npm:4.2.1"
   dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/55ba0fe366ddaa3f93e1faf8a70df0b67efedbd0008922295efe215df09b68df0ba3043293e65b17e7d1be71448d074c2bfc54e5eb6bd18f59b425822c2b9e9a
-  languageName: node
-  linkType: hard
-
-"@smithy/config-resolver@npm:^4.1.5":
-  version: 4.1.5
-  resolution: "@smithy/config-resolver@npm:4.1.5"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-config-provider": "npm:^4.0.0"
-    "@smithy/util-middleware": "npm:^4.0.5"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/f76f2365403411810a205763a6744eb84d4edfc6bedb87ba0d41b4b310b9c693f3cb17610f963f706b06e90c12864fe54617c9ff1f435fe3b94d825f2def2bfb
-  languageName: node
-  linkType: hard
-
-"@smithy/config-resolver@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/config-resolver@npm:4.2.0"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/types": "npm:^4.5.0"
     "@smithy/util-config-provider": "npm:^4.1.0"
-    "@smithy/util-middleware": "npm:^4.1.0"
+    "@smithy/util-middleware": "npm:^4.1.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a4b957028f60a27d2fe2611e4a972321d96987f92fe0b7ce65c1279c29b2cbd5a5f256a541a5648da06c5abef16b31a5ac94688af1af719bab39cd4c9f98dd2b
+  checksum: 10c0/fc60c55bff658ab102e256b2e9e67d0a75f62ce75025152897ba9ec4f2a71a387cd79f99892e21dd91a1352bff5b7f35da98bc6da335c224e8395a2fe1c280f8
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^3.10.0, @smithy/core@npm:^3.9.2":
-  version: 3.10.0
-  resolution: "@smithy/core@npm:3.10.0"
+"@smithy/core@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "@smithy/core@npm:3.11.0"
   dependencies:
-    "@smithy/middleware-serde": "npm:^4.1.0"
-    "@smithy/protocol-http": "npm:^5.2.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/middleware-serde": "npm:^4.1.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
     "@smithy/util-base64": "npm:^4.1.0"
     "@smithy/util-body-length-browser": "npm:^4.1.0"
-    "@smithy/util-middleware": "npm:^4.1.0"
-    "@smithy/util-stream": "npm:^4.3.0"
+    "@smithy/util-middleware": "npm:^4.1.1"
+    "@smithy/util-stream": "npm:^4.3.1"
     "@smithy/util-utf8": "npm:^4.1.0"
     "@types/uuid": "npm:^9.0.1"
     tslib: "npm:^2.6.2"
     uuid: "npm:^9.0.1"
-  checksum: 10c0/a30742bc4d5aeef0e0480a0d60caa9e4fd3ed76d7e519fe354357538cc06712db4105c855ca50c2d8d2a45b00edc88f0a68ffa0b49c1cf1e6457d91a8a0e8ee7
+  checksum: 10c0/290d088cc7a14b38c96943577d6bfde1b0c47588493c0b18dfacc98affb02a3d067f9b57d71a838bd79b46c3a7a10458f445eada37934bf308c1e21ae02b4b7d
   languageName: node
   linkType: hard
 
@@ -2196,142 +2174,129 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/credential-provider-imds@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/credential-provider-imds@npm:4.1.0"
+"@smithy/credential-provider-imds@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/credential-provider-imds@npm:4.1.1"
   dependencies:
-    "@smithy/node-config-provider": "npm:^4.2.0"
-    "@smithy/property-provider": "npm:^4.1.0"
-    "@smithy/types": "npm:^4.4.0"
-    "@smithy/url-parser": "npm:^4.1.0"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/property-provider": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/url-parser": "npm:^4.1.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e61013df07855c8f0275343d6b981948b62b86ce3a883111e5784be63e5bab307e0e1227ec97bce64f706dbdb4cb22d65ccf4cd231d4a96e3b0b1c06793d3063
+  checksum: 10c0/23b97ccc84f69b7ff4f68085b69585922650f95c23e1d18c78df4786616b93b928bab6a696162dfe369c6d3c9e667451614e1f7442fc8cfcaeb8183c6516fd73
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-codec@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/eventstream-codec@npm:4.0.5"
+"@smithy/eventstream-codec@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/eventstream-codec@npm:4.1.1"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-hex-encoding": "npm:^4.0.0"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-hex-encoding": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d94928e22468cb6e6d09bdc8a6ee04f05947c141c0b040aa90e95b6edc123ba03a562ff3994b5827c57295981183325ed8e8f6c60448a4eec392227735e86d62
+  checksum: 10c0/b3f3f11789cda08846d4e44065c870d30501b9c51042d756fab2fc3917b5886719a458cc4613890650cbcf9761b78fce8ead5add0385bc091c31fff186bbff85
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/eventstream-serde-browser@npm:4.0.5"
+"@smithy/eventstream-serde-browser@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/eventstream-serde-browser@npm:4.1.1"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/eventstream-serde-universal": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/352c6b73482d844f8184d6e6ffd28b1f69b376b59a3246a0ab967c990c15b11507323ff6362b27478062865e131739b27bafa7c6dedfa4c52ac8d795ce0cf8f5
+  checksum: 10c0/5062581b4f011aed2d86b819f876080054ff730af3d0c995aa0099570dc513056471746f3f09f48196b7bbec8119363f1f1f4f7151ac3e5aaf67d28bba57edbb
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.1.3"
+"@smithy/eventstream-serde-config-resolver@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.2.1"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/bfe98977649bcbfbe93cdbfb118c363759da6910ca8fa462870427dbc6f1f2f835103831147eee7eef27ace1bc58b65a40969c4630cf76be1eedfcd36996fd28
+  checksum: 10c0/93e31728e95b51d67c8ec61be074b12a5b6906af24ec3e2cee11c49f19f2cb95982b35c41eb8514498d409e10692e2baa68346938889c9d341e6443e039b4e74
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-node@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/eventstream-serde-node@npm:4.0.5"
+"@smithy/eventstream-serde-node@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/eventstream-serde-node@npm:4.1.1"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/eventstream-serde-universal": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/21c389202d2db2bcff23166b220ff3ba6c178f2b9eff1918317cca24c49cb6e0a53ab7f43fb8039f776f63ffd3a2bf69c909dafa5199d5d4278797cb121d3daa
+  checksum: 10c0/c92c6d0cb6e382f8c22188517cd31d8436866f229cead67c0bd02f961b998ae8bfffbce9a874638c4e55f0c52ffd9659e6e7b8b3f4dbb138bab79a4651eb46c2
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-universal@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/eventstream-serde-universal@npm:4.0.5"
+"@smithy/eventstream-serde-universal@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/eventstream-serde-universal@npm:4.1.1"
   dependencies:
-    "@smithy/eventstream-codec": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/eventstream-codec": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/183c6d4895395bbea34d12d3a87e9c69cc598c19e0cf51ba0036277ab520230fdc4b27026d1e438304b3ac4624a4408df15fc037f5c6a96bec0c71c400711170
+  checksum: 10c0/5b9c0271746b9556d3818ae0f7fc16ec2414a2a30885eeb4c68ad3e9d9665e06b36c9a4384f9ef188afc5e72e50f6c8a37d7a11d8185f46e5cb041918fcf5ed7
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@smithy/fetch-http-handler@npm:5.1.1"
+"@smithy/fetch-http-handler@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "@smithy/fetch-http-handler@npm:5.2.1"
   dependencies:
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/querystring-builder": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-base64": "npm:^4.0.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/c07f5cad58d5da7cd0de95e2d600e8dee8cda54bba65e7327c5beb25d2aa3eb815d228944bf20860de8927068d3d80baa28f71ecee0a1a3e131307774f53813b
-  languageName: node
-  linkType: hard
-
-"@smithy/fetch-http-handler@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "@smithy/fetch-http-handler@npm:5.2.0"
-  dependencies:
-    "@smithy/protocol-http": "npm:^5.2.0"
-    "@smithy/querystring-builder": "npm:^4.1.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/querystring-builder": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     "@smithy/util-base64": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/f8d2a9b169ba11f21c290e529768c874768926e59968bda6443b918ab2c3c205c97be85461e457c08f73dc2a65e3afd485826ff9636d0a1bb4affb7059f16532
+  checksum: 10c0/c4a6a1a67f84361045bd10fef470ec6cda8691f549a455f734cfd3de05ccefc300973188e55578ae379b936f7e3f842971447386a3d8ec728f7df9c2f1c58fc2
   languageName: node
   linkType: hard
 
-"@smithy/hash-blob-browser@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/hash-blob-browser@npm:4.0.5"
+"@smithy/hash-blob-browser@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/hash-blob-browser@npm:4.1.1"
   dependencies:
-    "@smithy/chunked-blob-reader": "npm:^5.0.0"
-    "@smithy/chunked-blob-reader-native": "npm:^4.0.0"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/chunked-blob-reader": "npm:^5.1.0"
+    "@smithy/chunked-blob-reader-native": "npm:^4.1.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d44a12847dabe3ba33b52306ef8f0f61ed22943d12a1fe2d669a5425d9e7b97fc1fd52b78bd362ba56a24c8f0723630e579f2de5362cddc9c8060854150545d9
+  checksum: 10c0/9188397ce2ee92bbac6147e3a342c981051e9623852198dc69de4899dd058ce5866222c663c166e6ddb6e9caa375e1b6296b5f7730026ec13a7d554009304571
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/hash-node@npm:4.0.5"
+"@smithy/hash-node@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/hash-node@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-buffer-from": "npm:^4.0.0"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-buffer-from": "npm:^4.1.0"
+    "@smithy/util-utf8": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/6c5aeba12b651d74fa05e03b7019d48193b0fac4995ad84fe313961c4e51d16cdbe46f529a3fe435a061fbe7eebee0620def92f9821add28e466152fd3270560
+  checksum: 10c0/aedf905c5fba7c814a697d973ea49c76d529dc9a10675676984a811637623b4f41542d72e53ed0df0a30881ee7fbe77c74bd49bd272e4a034e9d80021b6022a7
   languageName: node
   linkType: hard
 
-"@smithy/hash-stream-node@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/hash-stream-node@npm:4.0.5"
+"@smithy/hash-stream-node@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/hash-stream-node@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-utf8": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/19c7ce086eb86c3a8660a587c70278ab8e201aed10157e6c2f1a7d8071967429bf70b3cd6e81fb29042b3c3ffcf40866bc94ada34b86a1688dc28527884f10de
+  checksum: 10c0/91281943a0f198f01183a75ff62fd3fd8bc6708ee70e8d9a124d70f89042f3c300b42ceb58adb25ab5727df1810648c3e46ecf489b36a4020dc1c97a9003a771
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/invalid-dependency@npm:4.0.5"
+"@smithy/invalid-dependency@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/invalid-dependency@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8cc2a14dc47ac5513641747297e6e7e79dceb687e962e1520949db94597a5ce057f9f92657530b6660df100ef1fcff04cd5d9638847c8ada7f7b431a73f34fd2
+  checksum: 10c0/5700333f00b6a31a97b792fa9a00fadd07b2eafaea01087a6ea212753dba2621a040dfb0d7dc5a1f75bb95cc28fba2e498cdaca43009b142610944c0fcd95a58
   languageName: node
   linkType: hard
 
@@ -2362,101 +2327,80 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/md5-js@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/md5-js@npm:4.0.5"
+"@smithy/md5-js@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/md5-js@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-utf8": "npm:^4.0.0"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-utf8": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/30f015e5846963189aef4204029506c145e7c6106983bf0cb0ace88fcfc90c8a97094d65b73a79a86406bfcf70932bab9b7a6074fcac481afd0e078955bc95eb
+  checksum: 10c0/72d85566af8a318eb1599d483a51bb4eecd7204daba164fbefca04733e001ecc08fb1921815e399a5d5c8b46ab73804f8f5ac86501d4f5643d005733dc8a2360
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/middleware-content-length@npm:4.0.5"
+"@smithy/middleware-content-length@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/middleware-content-length@npm:4.1.1"
   dependencies:
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/2bbe3afc2d29bf4153afb52adb2cadc063e745c2e1f3c630ff10bb97ce4fa8ae7e6872082ec1407b638d0c7cb896ebcc27ca190f9aa78635a8e41a2440fe680a
+  checksum: 10c0/c841e9221f43303103076b3e2d0fb745b75f8caa0ec9cabb0be4fdb2c5a3fe4077391c083b6f8547ccdc58c44f267ee2423430e544bb95484d2b805e6008b8f3
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^4.1.21, @smithy/middleware-endpoint@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/middleware-endpoint@npm:4.2.0"
+"@smithy/middleware-endpoint@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@smithy/middleware-endpoint@npm:4.2.1"
   dependencies:
-    "@smithy/core": "npm:^3.10.0"
-    "@smithy/middleware-serde": "npm:^4.1.0"
-    "@smithy/node-config-provider": "npm:^4.2.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.1.0"
-    "@smithy/types": "npm:^4.4.0"
-    "@smithy/url-parser": "npm:^4.1.0"
-    "@smithy/util-middleware": "npm:^4.1.0"
+    "@smithy/core": "npm:^3.11.0"
+    "@smithy/middleware-serde": "npm:^4.1.1"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/shared-ini-file-loader": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/url-parser": "npm:^4.1.1"
+    "@smithy/util-middleware": "npm:^4.1.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/70704d829828f96c02ba6ecb1621b3e1329fea631efa261a96e0daf9bafbd91d6859c5d51c230575e9b4bac27c73d57b3ad054fe24716e14627bd948c66e7124
+  checksum: 10c0/0f63a4f6d0bf14efbfba5dd051171447c7364f1e4aef6c3f6ea8f6a99dc09cc7e2008ad88540d8491f4a7f109d9cf2fd4e874c6cb83c7702e71527b3cf81bde7
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^4.1.22":
-  version: 4.2.0
-  resolution: "@smithy/middleware-retry@npm:4.2.0"
+"@smithy/middleware-retry@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@smithy/middleware-retry@npm:4.2.1"
   dependencies:
-    "@smithy/node-config-provider": "npm:^4.2.0"
-    "@smithy/protocol-http": "npm:^5.2.0"
-    "@smithy/service-error-classification": "npm:^4.1.0"
-    "@smithy/smithy-client": "npm:^4.6.0"
-    "@smithy/types": "npm:^4.4.0"
-    "@smithy/util-middleware": "npm:^4.1.0"
-    "@smithy/util-retry": "npm:^4.1.0"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/service-error-classification": "npm:^4.1.1"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-middleware": "npm:^4.1.1"
+    "@smithy/util-retry": "npm:^4.1.1"
     "@types/uuid": "npm:^9.0.1"
     tslib: "npm:^2.6.2"
     uuid: "npm:^9.0.1"
-  checksum: 10c0/ee68ece2a077fd4f73522c9d404fa584df100ed0aa0f049f65bf1d48924e084ded9daf897d557e83a86b498c34d59011ad2291b89b4bcd68a4482a5b72cee186
+  checksum: 10c0/fc79e81d53e7bf910400fe786f3741bd1876bc62d6d326a18a3c62a973733ff1c771d68b3838bfe6deb72b197fdb06b61eb4048d1bae0b0ad1ecdd9cdb41e998
   languageName: node
   linkType: hard
 
-"@smithy/middleware-serde@npm:^4.0.9":
-  version: 4.0.9
-  resolution: "@smithy/middleware-serde@npm:4.0.9"
+"@smithy/middleware-serde@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/middleware-serde@npm:4.1.1"
   dependencies:
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/71dc9d920d36a3f65cc883718e8c74687a7c8074a148ab1a035e395e43c6566a3514f10b4c15a13b98194ecd1d81816932c9df8dfa5955cd347c6049893defc4
+  checksum: 10c0/69c0cf035da2ccbdf2838f50a1fafb0f8e6fb286b820e0aa91be7bdc6dd102f51ce3b295e68cdf9e7441dfc3160a3d3cabac99d98a8f0a75675ecf0f1e09d439
   languageName: node
   linkType: hard
 
-"@smithy/middleware-serde@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/middleware-serde@npm:4.1.0"
+"@smithy/middleware-stack@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/middleware-stack@npm:4.1.1"
   dependencies:
-    "@smithy/protocol-http": "npm:^5.2.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/cc44022522777c05445db06c15acd7886a23b1c499ae38b73b1153e8b10752feca644ece54168c5180b114201ea82f1b713dd5da6cf5a4c7374accde34346f71
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-stack@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/middleware-stack@npm:4.0.5"
-  dependencies:
-    "@smithy/types": "npm:^4.3.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/2ebe346b8b868d11bf9e5028a225ad1312f7862231ae01c289059291b984127a7c18e17f1fa4d803de09f77441d839bc5e25f8ec9bed10a9a320d0393bc55930
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-stack@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/middleware-stack@npm:4.1.0"
-  dependencies:
-    "@smithy/types": "npm:^4.4.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/4437f06e263587138030d6b1f6612aa4848041ab398999f626da8f3954c6046ec0e602c28daa451eeeab365b7812805fd1afc2562ad267a102f3de6f62625c58
+  checksum: 10c0/8ee554c30e6802f6adcaf673e4d216cd8f56e13a9ef5d644ec94f0b553c3b62b451a8156fd49645cc1f5eedd09234a107edc42faff779416a4a43a215e370007
   languageName: node
   linkType: hard
 
@@ -2472,41 +2416,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-config-provider@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/node-config-provider@npm:4.2.0"
+"@smithy/node-config-provider@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@smithy/node-config-provider@npm:4.2.1"
   dependencies:
-    "@smithy/property-provider": "npm:^4.1.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.1.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/property-provider": "npm:^4.1.1"
+    "@smithy/shared-ini-file-loader": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/785af2cbfb8c5cd7a67069230f62f84c6492742bc622791375675a519d743dc7965854aea5bfcaa3b92ba9f3cdebe99786570bb6919dbe89ac245130254c0bd0
+  checksum: 10c0/ef648e075a36a0f543b9fdd51c2e250a2516934f6719331153a45f57d2fd5f367073a311b7fd5b03cdd19031282492a5be8b83df456dddf5186ff128f9ceae85
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "@smithy/node-http-handler@npm:4.1.1"
+"@smithy/node-http-handler@npm:^4.2.1, @smithy/node-http-handler@npm:~4.2.1":
+  version: 4.2.1
+  resolution: "@smithy/node-http-handler@npm:4.2.1"
   dependencies:
-    "@smithy/abort-controller": "npm:^4.0.5"
-    "@smithy/protocol-http": "npm:^5.1.3"
-    "@smithy/querystring-builder": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/abort-controller": "npm:^4.1.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/querystring-builder": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a61a841bc6e69c62a983031e8b3faf1ab82abaf0ccd1eb5d3e02e3d99a8be020fa8dff0b2b1f81468db43e0e7be2407785b89e9c6c04035b8b4afde08bed3a98
-  languageName: node
-  linkType: hard
-
-"@smithy/node-http-handler@npm:^4.2.0, @smithy/node-http-handler@npm:~4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/node-http-handler@npm:4.2.0"
-  dependencies:
-    "@smithy/abort-controller": "npm:^4.1.0"
-    "@smithy/protocol-http": "npm:^5.2.0"
-    "@smithy/querystring-builder": "npm:^4.1.0"
-    "@smithy/types": "npm:^4.4.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/2b899b5fb709d635fa0c4da1482436965cfa8c9bda1663936c3ceb458a54ada64f6deb2e6ca832d618942bbcbbf900e823689259f5b709164c07d33718e0da23
+  checksum: 10c0/7536923c62b0bbbade8335b25368d02b4840cd381aba9dbdadb472fb501576d7b3b73121069356b022e9da3ec5d27711a00ec7786d31ba15089abdce582121cc
   languageName: node
   linkType: hard
 
@@ -2520,13 +2451,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/property-provider@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/property-provider@npm:4.1.0"
+"@smithy/property-provider@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/property-provider@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a2af26b4e0dfefebb998decd9d4b19349030b3cdebc6fc3287974f06c8207e9b0b40a4f56a9a950d21711dcb580644e47db5c6b66a1f8f2f6a774865681a763a
+  checksum: 10c0/5aa28b7e6cc23baf3605aa3be8a33ae4943635e698e0de773e8056f5ad06494f370f23cd3c4d083245d6fe411c25c38a76887d38a36d5daf075e36e6e6e3864f
   languageName: node
   linkType: hard
 
@@ -2540,35 +2471,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "@smithy/protocol-http@npm:5.2.0"
+"@smithy/protocol-http@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "@smithy/protocol-http@npm:5.2.1"
   dependencies:
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a1e0212b55fa071d89189fc8a5f339499e8862f567f5e4c2888c53eece3815939221684d6bd6782d8b572305734cf3bb229a29f13273671f810c804fa50833d3
+  checksum: 10c0/b27df0a94f8e0bab1e8310da82c3048e6d397a3b52f8413c4f19bb9c13d11afcdf7424293cb8d8d3e867b07ff8c5f3c8d0fbdd7d07a8328a39721eb202336d2b
   languageName: node
   linkType: hard
 
-"@smithy/querystring-builder@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@smithy/querystring-builder@npm:4.0.5"
+"@smithy/querystring-builder@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/querystring-builder@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-uri-escape": "npm:^4.0.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/649a046a14f25d5febba341dedd577c9fce80aa86970dc2af0b0289a2b6326731c19ddefcae172a0162a4a73306ad823533528751a0067c910efce3cabe06675
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-builder@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/querystring-builder@npm:4.1.0"
-  dependencies:
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/types": "npm:^4.5.0"
     "@smithy/util-uri-escape": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/54b0f19970b90ee0efa52611007c3c096bb99028bce0da88beb7ccf8548db46332c7012776fd3ce17ae927c89c03e6a9471b874fce9469b99edd3a02c9d56e7e
+  checksum: 10c0/15d41888eae29f57dbf9d2c8caa449d19ebb760b83958a0fe2cf4858948bb6e0466c176a207b868d8af7785e8f6688b87ada4e364ec6fd729ab6bffbd64b92d8
   languageName: node
   linkType: hard
 
@@ -2582,31 +2502,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/querystring-parser@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/querystring-parser@npm:4.1.0"
+"@smithy/querystring-parser@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/querystring-parser@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/88e698853f9e7e481ed05fa6dca27e60a0206cc0efb1770e29c2f6a8850be5f49d7f75618c198da143f1a39631522fae7a9635e8d4d22d6167df421f80017726
+  checksum: 10c0/6bf8672aca07826af16625b41f20332fdfdc39861124e026ee929e4652f638edc7107d347a2fe7feb0c2e6f2c98d149d2d383cecaab46a48a990f36333e8f016
   languageName: node
   linkType: hard
 
-"@smithy/service-error-classification@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "@smithy/service-error-classification@npm:4.0.7"
+"@smithy/service-error-classification@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/service-error-classification@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.3.2"
-  checksum: 10c0/fe44ce36c8759c74a63adc52c47b638ee0a34ea32752d9c5923c370f0497a412ced51d8b83e444303d8d9d544d30d3d16fecb39c9f5cda8622b293704ce999a2
-  languageName: node
-  linkType: hard
-
-"@smithy/service-error-classification@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/service-error-classification@npm:4.1.0"
-  dependencies:
-    "@smithy/types": "npm:^4.4.0"
-  checksum: 10c0/14f65f54aea8f5598e69d6d22e2c44c3f790434837701ac04627f51791551af094d8c26a6b8ef752c8f8d3fbec2dd6a268c33d40e6af1a0bade9ac3cb905bc41
+    "@smithy/types": "npm:^4.5.0"
+  checksum: 10c0/946d3b7cc642d665a1717c69fdf7df4256a6fe03d3686be8fa9c514c6ff185eaee5a4ac5d0f45958087e8750a2fcba67f30e5567457889b54684e7dd00dfd400
   languageName: node
   linkType: hard
 
@@ -2620,13 +2531,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/shared-ini-file-loader@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/shared-ini-file-loader@npm:4.1.0"
+"@smithy/shared-ini-file-loader@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/shared-ini-file-loader@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c3dab2b4c4844ddd38d8862c6bed03e442c1d8c70d88b81d8f1597bb61a21142ce63a6eb802236cc7690468b7d7eb69c49e4e5d08693d12a4b9c4109c2ccff12
+  checksum: 10c0/1768c3f11519bd73797a63c062dd6ff26dd3cc1d7fc1ae5a5d92209fb8d3140a8799258a854ef0efbda27d19de619e608599c0d870539c251c504c3a56999a60
   languageName: node
   linkType: hard
 
@@ -2646,18 +2557,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^4.5.2, @smithy/smithy-client@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "@smithy/smithy-client@npm:4.6.0"
+"@smithy/smithy-client@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "@smithy/smithy-client@npm:4.6.1"
   dependencies:
-    "@smithy/core": "npm:^3.10.0"
-    "@smithy/middleware-endpoint": "npm:^4.2.0"
-    "@smithy/middleware-stack": "npm:^4.1.0"
-    "@smithy/protocol-http": "npm:^5.2.0"
-    "@smithy/types": "npm:^4.4.0"
-    "@smithy/util-stream": "npm:^4.3.0"
+    "@smithy/core": "npm:^3.11.0"
+    "@smithy/middleware-endpoint": "npm:^4.2.1"
+    "@smithy/middleware-stack": "npm:^4.1.1"
+    "@smithy/protocol-http": "npm:^5.2.1"
+    "@smithy/types": "npm:^4.5.0"
+    "@smithy/util-stream": "npm:^4.3.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d8d6ccf506d1cffae967565442aa28a288cd97fd2f88d14cf359b18ab99cbe99001421bcc3b6a49b766fe63222e87cb9debe74f372d9756242b8c5ef891c5c43
+  checksum: 10c0/16c8aa6e44db638c7353e6e0068275cc30934650e8f67f1721e8adfcaad75dbe0eb4f2e9596e3a284f8f5528e1e26eab34f7ab9dab1398fae74d678b24446ef8
   languageName: node
   linkType: hard
 
@@ -2670,12 +2581,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^4.3.2, @smithy/types@npm:^4.4.0":
+"@smithy/types@npm:^4.3.2":
   version: 4.4.0
   resolution: "@smithy/types@npm:4.4.0"
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/af7b78cf16be45c65b3e4dcde37589e49d501981f53ce9d3382d66d60b22d975bccfcf417fb42eae59416215d581b0f6136be04ebf17e88bc0dc91b47d2dddd1
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "@smithy/types@npm:4.5.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7c765c9316893ab9e6575ba40e3d1569d43d7d1edd1110b505e190a4aa378a89e407b6f92de7bf0f22342ce05228ff0f1d37b14781e41c60c429fc22c8e5bae9
   languageName: node
   linkType: hard
 
@@ -2690,25 +2610,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/url-parser@npm:4.1.0"
+"@smithy/url-parser@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/url-parser@npm:4.1.1"
   dependencies:
-    "@smithy/querystring-parser": "npm:^4.1.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/querystring-parser": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/be71635e8fcbcf6868a461f71459d82d8ae619277454609ff70d848c92043d1dc4fc521149f0b6372e76b227aabdf11094a65c8bf64eaa48ee1ac6cdc53a2fbd
-  languageName: node
-  linkType: hard
-
-"@smithy/util-base64@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-base64@npm:4.0.0"
-  dependencies:
-    "@smithy/util-buffer-from": "npm:^4.0.0"
-    "@smithy/util-utf8": "npm:^4.0.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/ad18ec66cc357c189eef358d96876b114faf7086b13e47e009b265d0ff80cec046052500489c183957b3a036768409acdd1a373e01074cc002ca6983f780cffc
+  checksum: 10c0/1f9e19d5d1e1a4874cf2f61df014715dc3685be385356758d3aed1a6b020b074af22961b12ae651faad74ed0460a102156471543031e74c726770820ede6f31c
   languageName: node
   linkType: hard
 
@@ -2723,15 +2632,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-browser@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-body-length-browser@npm:4.0.0"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/574a10934024a86556e9dcde1a9776170284326c3dfcc034afa128cc5a33c1c8179fca9cfb622ef8be5f2004316cc3f427badccceb943e829105536ec26306d9
-  languageName: node
-  linkType: hard
-
 "@smithy/util-body-length-browser@npm:^4.1.0":
   version: 4.1.0
   resolution: "@smithy/util-body-length-browser@npm:4.1.0"
@@ -2741,12 +2641,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-node@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-body-length-node@npm:4.0.0"
+"@smithy/util-body-length-node@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/util-body-length-node@npm:4.1.0"
   dependencies:
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e91fd3816767606c5f786166ada26440457fceb60f96653b3d624dcf762a8c650e513c275ff3f647cb081c63c283cc178853a7ed9aa224abc8ece4eeeef7a1dd
+  checksum: 10c0/d31fb7be66eb481f865d046b48c07221d25108b07c783f05eff7f165369d2259ca01de7c369f9de95e37e989b1344521bc6d4a6b38b42a7a46375a0c97f38a0b
   languageName: node
   linkType: hard
 
@@ -2798,42 +2698,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^4.0.29":
-  version: 4.1.0
-  resolution: "@smithy/util-defaults-mode-browser@npm:4.1.0"
+"@smithy/util-defaults-mode-browser@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.1.1"
   dependencies:
-    "@smithy/property-provider": "npm:^4.1.0"
-    "@smithy/smithy-client": "npm:^4.6.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/property-provider": "npm:^4.1.1"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
     bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/0732e78f4c4a4cc6dafbad077fbe7314cf35abaaba8c2e1fd7e3eeb3f7ef8860774bc7861d52040b23dbce20facbd7bd6c76b3e46a8b241bd6da82a4c6af48d8
+  checksum: 10c0/dd1e1e449ca44c50a7f6b0cfac51e40426f1034309921bcd6a591c9afdc09b5cb7d34685202a504cdded183297e4f455bb2404ebe012e912195ba32397ac7886
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^4.0.29":
-  version: 4.1.0
-  resolution: "@smithy/util-defaults-mode-node@npm:4.1.0"
+"@smithy/util-defaults-mode-node@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/util-defaults-mode-node@npm:4.1.1"
   dependencies:
-    "@smithy/config-resolver": "npm:^4.2.0"
-    "@smithy/credential-provider-imds": "npm:^4.1.0"
-    "@smithy/node-config-provider": "npm:^4.2.0"
-    "@smithy/property-provider": "npm:^4.1.0"
-    "@smithy/smithy-client": "npm:^4.6.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/config-resolver": "npm:^4.2.1"
+    "@smithy/credential-provider-imds": "npm:^4.1.1"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/property-provider": "npm:^4.1.1"
+    "@smithy/smithy-client": "npm:^4.6.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/eed450e20146ae20559c0dd1bc43ea5679b3b34373d9ce9be0795af55c3fb4c085fd84e2fc2f1c1caefcdbfe2e617888502c5badfcaa3ffaadd55896cc6fb1de
+  checksum: 10c0/4296c76e2bf7af52a71bfa7811e4f0f070fd5e02da4b51ec35d23a2c3b32382a163d0c3d90a397cdcf4147fde1816e9b57081c9553b234b85159b0ddbed0d570
   languageName: node
   linkType: hard
 
-"@smithy/util-endpoints@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/util-endpoints@npm:3.0.7"
+"@smithy/util-endpoints@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@smithy/util-endpoints@npm:3.1.1"
   dependencies:
-    "@smithy/node-config-provider": "npm:^4.1.4"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/node-config-provider": "npm:^4.2.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7024005a8a4f77ebae52d1dce538d76db3567c6fb22b06ba601dba4d4d8668cb4dbadd229015d02bb6bdb1a5aaa6b2d1c826cfcf412257ceb9dfe52c7ab95fca
+  checksum: 10c0/bb1bcd08c217dc6a7a55f18fa2277af3d43d4072894cbba8d0af8edb3942ef50a276f011f670f6236010ab65d34b148f67c114d598944de433fa3496439c77fa
   languageName: node
   linkType: hard
 
@@ -2865,67 +2765,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-middleware@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/util-middleware@npm:4.1.0"
+"@smithy/util-middleware@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/util-middleware@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/cf2053f43da72d64a43c078e89addd6aeec5027afe5200a839dad532a78f2fac4dbfd6fd8ef7a68d63eb111a252fb7bd558ef79ae007ef6385308566697fda9b
+  checksum: 10c0/47bee56b2fbf9fbe3c4be4e1daac247fea889848d43120c64895529bb92ef43b25cf07213792d1646622356a1572b91cc48b0976c39667a9020edfa5ec58d093
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "@smithy/util-retry@npm:4.0.7"
+"@smithy/util-retry@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/util-retry@npm:4.1.1"
   dependencies:
-    "@smithy/service-error-classification": "npm:^4.0.7"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/service-error-classification": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/09c633f59ac51203d917548ceb4caf7678e24c87eea024e97e8d62a918be4a76a1c517622b7e9841cf0e9f50778d6787f62efe6c25ae514ed7068e2323303c72
+  checksum: 10c0/25f07dbf9be8798d2792b2ebfd68506408797815fc4ef75a6f526f52d3c6e6f7a53723f6c46b6a44855ed3cebee4da5a49a86c4e8b2e8b923e39aff965b00e7d
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/util-retry@npm:4.1.0"
+"@smithy/util-stream@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@smithy/util-stream@npm:4.3.1"
   dependencies:
-    "@smithy/service-error-classification": "npm:^4.1.0"
-    "@smithy/types": "npm:^4.4.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/b3fd78264e9e5a2f3545affac2f19410bd1afa4b429376e7f60180a8059990ce9f3e35ceed9801ca9d65e5743406ce694a6cede7df92fef105de7612c85a1d56
-  languageName: node
-  linkType: hard
-
-"@smithy/util-stream@npm:^4.2.4":
-  version: 4.2.4
-  resolution: "@smithy/util-stream@npm:4.2.4"
-  dependencies:
-    "@smithy/fetch-http-handler": "npm:^5.1.1"
-    "@smithy/node-http-handler": "npm:^4.1.1"
-    "@smithy/types": "npm:^4.3.2"
-    "@smithy/util-base64": "npm:^4.0.0"
-    "@smithy/util-buffer-from": "npm:^4.0.0"
-    "@smithy/util-hex-encoding": "npm:^4.0.0"
-    "@smithy/util-utf8": "npm:^4.0.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/45d2945656a68822272eb5e37e447bd161861722d841712d087cc0aaf93ad0da8162eef2164d1a35f55a7124cb8815b357b766c21442b23ea972b1d5345f0526
-  languageName: node
-  linkType: hard
-
-"@smithy/util-stream@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@smithy/util-stream@npm:4.3.0"
-  dependencies:
-    "@smithy/fetch-http-handler": "npm:^5.2.0"
-    "@smithy/node-http-handler": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.4.0"
+    "@smithy/fetch-http-handler": "npm:^5.2.1"
+    "@smithy/node-http-handler": "npm:^4.2.1"
+    "@smithy/types": "npm:^4.5.0"
     "@smithy/util-base64": "npm:^4.1.0"
     "@smithy/util-buffer-from": "npm:^4.1.0"
     "@smithy/util-hex-encoding": "npm:^4.1.0"
     "@smithy/util-utf8": "npm:^4.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/97e1577b2804d3e182b6d09dd1c93222b745726fec542648036823fb748c3a420006a401accd4b819099121a5df00b96921c078ce2b3d4f43ade6341541ce3ae
+  checksum: 10c0/7fd8fde8b011fe3535799d9a60195fe8e1229c6976b76d3bf930dbb9d27204754acbf082816cdacaa00e77857ab9e4b673c331c6626aba7ef242cdb7e143b028
   languageName: node
   linkType: hard
 
@@ -2977,30 +2850,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "@smithy/util-waiter@npm:4.0.7"
+"@smithy/util-waiter@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/util-waiter@npm:4.1.1"
   dependencies:
-    "@smithy/abort-controller": "npm:^4.0.5"
-    "@smithy/types": "npm:^4.3.2"
+    "@smithy/abort-controller": "npm:^4.1.1"
+    "@smithy/types": "npm:^4.5.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/14caffd913b9b18ff4f33d6bb1f05eef2e354104a6db2b69654d7db4582c4be46b202d46af87a66177a8a3a99082fa8b0948195de8aeb63998c6ed5b04f2bd3d
+  checksum: 10c0/0ecdaa4b8a2036f753e0ad6c2a4f3c98b069b98f16525db9e8219aaceb189e78b46ebcd8829210874cc44a4693f9a83da9eb96315c2ed30f379065b821d6447c
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin@npm:~5.2.3":
-  version: 5.2.3
-  resolution: "@stylistic/eslint-plugin@npm:5.2.3"
+"@stylistic/eslint-plugin@npm:~5.3.1":
+  version: 5.3.1
+  resolution: "@stylistic/eslint-plugin@npm:5.3.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/types": "npm:^8.38.0"
+    "@typescript-eslint/types": "npm:^8.41.0"
     eslint-visitor-keys: "npm:^4.2.1"
     espree: "npm:^10.4.0"
     estraverse: "npm:^5.3.0"
     picomatch: "npm:^4.0.3"
   peerDependencies:
     eslint: ">=9.0.0"
-  checksum: 10c0/335cdb779e0afd2d2dc40ee58eb9f04c1d7ac51317c46834e3f0c0839746b8810a18af4268853a0f3c2b330976b9e5cf2753c3fac22a42e8976c0575602b2985
+  checksum: 10c0/806a96beae7744b37f5f60c9f3ed074f6abb64afe009d58d99f33b30723101d0c6ed9ccbcdbc1418c9e9842a46f689aa52fae67a44ce5c55b1540ad7218e6939
   languageName: node
   linkType: hard
 
@@ -3013,27 +2886,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:~1.1.24":
-  version: 1.1.24
-  resolution: "@terascope/eslint-config@npm:1.1.24"
+"@terascope/eslint-config@npm:~1.1.25":
+  version: 1.1.25
+  resolution: "@terascope/eslint-config@npm:1.1.25"
   dependencies:
     "@eslint/compat": "npm:~1.3.2"
-    "@eslint/js": "npm:~9.34.0"
-    "@stylistic/eslint-plugin": "npm:~5.2.3"
-    "@typescript-eslint/eslint-plugin": "npm:~8.40.0"
-    "@typescript-eslint/parser": "npm:~8.40.0"
-    eslint: "npm:~9.34.0"
+    "@eslint/js": "npm:~9.35.0"
+    "@stylistic/eslint-plugin": "npm:~5.3.1"
+    "@typescript-eslint/eslint-plugin": "npm:~8.43.0"
+    "@typescript-eslint/parser": "npm:~8.43.0"
+    eslint: "npm:~9.35.0"
     eslint-plugin-import: "npm:~2.32.0"
     eslint-plugin-jest: "npm:~29.0.1"
     eslint-plugin-jest-dom: "npm:~5.5.0"
     eslint-plugin-jsx-a11y: "npm:~6.10.2"
     eslint-plugin-react: "npm:~7.37.5"
     eslint-plugin-react-hooks: "npm:~5.2.0"
-    eslint-plugin-testing-library: "npm:~7.6.6"
+    eslint-plugin-testing-library: "npm:~7.6.8"
     globals: "npm:~16.3.0"
     typescript: "npm:~5.9.2"
-    typescript-eslint: "npm:~8.40.0"
-  checksum: 10c0/5081f3d18ff3be0bf632f76f818832e48e2222b84d2cb24261c07d2374467aa47924deea326e34bf87cddcaa7fda01827019e897e3af8e4c699d962299a09d61
+    typescript-eslint: "npm:~8.43.0"
+  checksum: 10c0/e138bb89df2a9f3e8d9c8f9a782ff6c979dedceb52c14591e1bce52b58e6db05988b670b938719264dccac9a8670e61304992276f383de2256ac745cc8cf0e4e
   languageName: node
   linkType: hard
 
@@ -3056,10 +2929,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/file-asset-apis@workspace:packages/file-asset-apis"
   dependencies:
-    "@aws-sdk/client-s3": "npm:~3.884.0"
-    "@smithy/node-http-handler": "npm:~4.2.0"
-    "@terascope/scripts": "npm:~1.21.5"
-    "@terascope/utils": "npm:~1.10.2"
+    "@aws-sdk/client-s3": "npm:~3.888.0"
+    "@smithy/node-http-handler": "npm:~4.2.1"
+    "@terascope/scripts": "npm:~1.21.6"
+    "@terascope/utils": "npm:~1.10.3"
     "@types/jest": "npm:~30.0.0"
     aws-sdk-client-mock: "npm:~4.1.0"
     csvtojson: "npm:~2.0.10"
@@ -3074,34 +2947,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/job-components@npm:~1.12.2":
-  version: 1.12.2
-  resolution: "@terascope/job-components@npm:1.12.2"
+"@terascope/job-components@npm:~1.12.3":
+  version: 1.12.3
+  resolution: "@terascope/job-components@npm:1.12.3"
   dependencies:
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     datemath-parser: "npm:~1.0.6"
-    import-meta-resolve: "npm:~4.1.0"
+    import-meta-resolve: "npm:~4.2.0"
     prom-client: "npm:~15.1.3"
     semver: "npm:~7.7.2"
-    uuid: "npm:~11.1.0"
-  checksum: 10c0/e79513ec70b9ee5564ea1b12cb9cae1f58323e8e1d923e61843d6e42b4418f89e0c2d10624e5029ec11cbab51f1cedd699fab74f146518d7271ab06125b28998
+    uuid: "npm:~12.0.0"
+  checksum: 10c0/698b915d32872b9efe13c7459c5d3d96b3c9632e7f8a9373467752a51e90807c29ebae1d8d5bffc3318a09d25c33552a96b9724826e72c767f7f037281a3ea82
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.21.5":
-  version: 1.21.5
-  resolution: "@terascope/scripts@npm:1.21.5"
+"@terascope/scripts@npm:~1.21.6":
+  version: 1.21.6
+  resolution: "@terascope/scripts@npm:1.21.6"
   dependencies:
     "@kubernetes/client-node": "npm:~1.3.0"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     execa: "npm:~9.6.0"
     fs-extra: "npm:~11.3.1"
     globby: "npm:~14.1.0"
-    got: "npm:~14.4.7"
+    got: "npm:~14.4.8"
     ip: "npm:~2.0.1"
     js-yaml: "npm:~4.1.0"
     kafkajs: "npm:~2.2.4"
@@ -3114,7 +2987,7 @@ __metadata:
     signale: "npm:~1.4.0"
     sort-package-json: "npm:~3.4.0"
     toposort: "npm:~2.0.2"
-    typedoc: "npm:~0.28.11"
+    typedoc: "npm:~0.28.12"
     typedoc-plugin-markdown: "npm:~4.8.1"
     yaml: "npm:^2.8.1"
     yargs: "npm:~18.0.0"
@@ -3125,7 +2998,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/e6ff8ddcf3b934eb5f25f883b27e0761e06656356cbde0d0e8830b3d111246ae92e0ce9ecc0611d0ffc92bc8cda8ba607810122def14ffccd1718278a23e6f92
+  checksum: 10c0/40aa7b988af8790950c0b0c7f69e4988b58f2adf2650e88029da69aee1148ae51dbe7422f925d58b6fe801469506debb1b5aa0364cbbc0ebdfceb1871aa1f64d
   languageName: node
   linkType: hard
 
@@ -3138,9 +3011,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.10.2":
-  version: 1.10.2
-  resolution: "@terascope/utils@npm:1.10.2"
+"@terascope/utils@npm:~1.10.3":
+  version: 1.10.3
+  resolution: "@terascope/utils@npm:1.10.3"
   dependencies:
     "@chainsafe/is-ip": "npm:~2.1.0"
     "@terascope/types": "npm:~1.4.4"
@@ -3164,7 +3037,7 @@ __metadata:
     datemath-parser: "npm:~1.0.6"
     debug: "npm:~4.4.1"
     geo-tz: "npm:~8.1.4"
-    ip-bigint: "npm:~8.2.1"
+    ip-bigint: "npm:~8.2.2"
     ip-cidr: "npm:~4.0.2"
     ip6addr: "npm:~0.2.5"
     ipaddr.js: "npm:~2.2.0"
@@ -3178,7 +3051,7 @@ __metadata:
     p-map: "npm:~7.0.3"
     shallow-clone: "npm:~3.0.1"
     validator: "npm:~13.12.0"
-  checksum: 10c0/a088410dce937c6a0239966e3f30c13ff29dc3cccefabbc42873926d724507a42f0c1b778893b8dbe165e9801b01bc4d3144d1fb471020050f16b352a2be4683
+  checksum: 10c0/a0dba5d6b60e68c06015b70fc9e3cba07689b2b401fc893a478e64c07ee59dc3576eb6420e8ea276abb6622e2816a13cf80fae5a8dab651db0b7ebc8876ce1ac
   languageName: node
   linkType: hard
 
@@ -3635,12 +3508,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~24.3.1":
-  version: 24.3.1
-  resolution: "@types/node@npm:24.3.1"
+"@types/node@npm:~24.4.0":
+  version: 24.4.0
+  resolution: "@types/node@npm:24.4.0"
   dependencies:
-    undici-types: "npm:~7.10.0"
-  checksum: 10c0/99b86fc32294fcd61136ca1f771026443a1e370e9f284f75e243b29299dd878e18c193deba1ce29a374932db4e30eb80826e1049b9aad02d36f5c30b94b6f928
+    undici-types: "npm:~7.11.0"
+  checksum: 10c0/3aefa4c6b006b3478f2d28a48d830ab7350ce24efdaf352011418e3ee17ed7683ca9c0a1840e770685ce78f413344badafa91e034be02488efe2eb6b612bd542
   languageName: node
   linkType: hard
 
@@ -3736,40 +3609,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.40.0, @typescript-eslint/eslint-plugin@npm:~8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.40.0"
+"@typescript-eslint/eslint-plugin@npm:8.43.0, @typescript-eslint/eslint-plugin@npm:~8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.43.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.40.0"
-    "@typescript-eslint/type-utils": "npm:8.40.0"
-    "@typescript-eslint/utils": "npm:8.40.0"
-    "@typescript-eslint/visitor-keys": "npm:8.40.0"
+    "@typescript-eslint/scope-manager": "npm:8.43.0"
+    "@typescript-eslint/type-utils": "npm:8.43.0"
+    "@typescript-eslint/utils": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.40.0
+    "@typescript-eslint/parser": ^8.43.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/dc8889c3255bce6956432f099059179dd13826ba29670f81ba9238ecde46764ee63459eb73a7d88f4f30e1144a2f000d79c9e3f256fa759689d9b3b74d423bda
+  checksum: 10c0/9823f6e917d16f95a87fb1fd6c224f361a9f17386453ac97d7d457774cf2ea7bdbcfad37ad063b71ec01a4292127a8bfe69d1987b948e85def2410de8fe353dd
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.40.0, @typescript-eslint/parser@npm:~8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/parser@npm:8.40.0"
+"@typescript-eslint/parser@npm:8.43.0, @typescript-eslint/parser@npm:~8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/parser@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.40.0"
-    "@typescript-eslint/types": "npm:8.40.0"
-    "@typescript-eslint/typescript-estree": "npm:8.40.0"
-    "@typescript-eslint/visitor-keys": "npm:8.40.0"
+    "@typescript-eslint/scope-manager": "npm:8.43.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/43ca9589b8a1f3f4b30a214c0e2254fa0ad43458ef1258b1d62c5aad52710ad11b9315b124cda79163274147b82201a5d76fab7de413e34bfe8e377142b71e98
+  checksum: 10c0/b8296d3fac08f6e03c931843264a4219469a6a7d5c4d269fb14fe4c1547477a0dd1c259e6929c749efa043fb4e272436adfc94afdf07039d3b1d9e6956a6a0ea
   languageName: node
   linkType: hard
 
@@ -3783,6 +3656,19 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
   checksum: 10c0/23d62e9ada9750136d0251f268bbe1f9784442ef258bb340a2e1e866749d8076730a14749d9a320d94d7c76df2d108caf21fe35e5dc100385f04be846dc979cb
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/project-service@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/project-service@npm:8.43.0"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.43.0"
+    "@typescript-eslint/types": "npm:^8.43.0"
+    debug: "npm:^4.3.4"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/c9058b5fbf9642c35a303641e4ff2d0df1ddac337275bab84b56167f1019fbcb7e69959239fed82e53c747f58d6ee4c1859cf5b018803cba1b1aab430439d728
   languageName: node
   linkType: hard
 
@@ -3806,6 +3692,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.43.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
+  checksum: 10c0/f87b3c3a5d3ad18326945288fa5b9b9fa662d87f466dc159e1514e00e359e830b80557f213acb3d23d5d600826b4cc4cfa5d2d479f8aba1b9834df19a640a779
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.40.0, @typescript-eslint/tsconfig-utils@npm:^8.40.0":
   version: 8.40.0
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.40.0"
@@ -3815,19 +3711,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/type-utils@npm:8.40.0"
+"@typescript-eslint/tsconfig-utils@npm:8.43.0, @typescript-eslint/tsconfig-utils@npm:^8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.43.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/b3a472368ad31e31e58ef019f6afec7387f5885e3fd423c71f3910b6d6b767324fde8bd60bec2e7505cc130317ece7fbc91314c44cdfea74ff76b5039bf26d52
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/type-utils@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.40.0"
-    "@typescript-eslint/typescript-estree": "npm:8.40.0"
-    "@typescript-eslint/utils": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
+    "@typescript-eslint/utils": "npm:8.43.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/660b77d801b2538a4ccb65065269ad0e8370d0be985172b5ecb067f3eea22e64aa8af9e981b31bf2a34002339fe3253b09b55d181ce6d8242fc7daa80ac4aaca
+  checksum: 10c0/70e61233fd586c4545b0ee11871001ba603816fccb69b9fe883a653b32aa049e957a97f208f522b58480a4f4e1c6322b9a3ef60a389925eaefba94abcd44ff7e
   languageName: node
   linkType: hard
 
@@ -3838,10 +3743,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.40.0, @typescript-eslint/types@npm:^8.38.0, @typescript-eslint/types@npm:^8.40.0":
+"@typescript-eslint/types@npm:8.40.0, @typescript-eslint/types@npm:^8.40.0":
   version: 8.40.0
   resolution: "@typescript-eslint/types@npm:8.40.0"
   checksum: 10c0/225374fff36d59288a5780667a7a1316c75090d5d60b70a8035ac18786120333ccd08dfdf0e05e30d5a82217e44c57b8708b769dd1eed89f12f2ac4d3a769f76
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.43.0, @typescript-eslint/types@npm:^8.41.0, @typescript-eslint/types@npm:^8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/types@npm:8.43.0"
+  checksum: 10c0/60d19b695affce128fe1076ebe4cff7e05d38dd50155d653fc9e995eafa56c299fd49ad4d9d2997f118a75fb57e3ca18001623bc3ef3fa0111f863079203e4b2
   languageName: node
   linkType: hard
 
@@ -3884,7 +3796,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.40.0, @typescript-eslint/utils@npm:^8.0.0":
+"@typescript-eslint/typescript-estree@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.43.0"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.43.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.43.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.1.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/184ba925067d7fbcb377450195a89511f030a49d080e27058fa78078a069d86c1936b1a82ce6f19ff24c30c4de8b779deb050c36b06db5372c95fc7e5be7115a
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/utils@npm:8.43.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.7.0"
+    "@typescript-eslint/scope-manager": "npm:8.43.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/42fc8c60551361d80b5c53b303ba8cd20cf914665168416ad0a278cd44aae587311af9e4461f92ed28b5f36091d275a0e9974482d5e9ba95fc00108a537cdd36
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^8.0.0":
   version: 8.40.0
   resolution: "@typescript-eslint/utils@npm:8.40.0"
   dependencies:
@@ -3933,6 +3880,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.40.0"
     eslint-visitor-keys: "npm:^4.2.1"
   checksum: 10c0/592f1c8c2d3da43a7f74f8ead14f05fafc2e4609d5df36811cf92ead5dc94f6f669556a494048e4746cb3774c60bc52a8c83d75369d5e196778d935c70e7d3a1
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.43.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.43.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10c0/5d576eaf7bea41933ba726f4b24410bd3fc2521ef286967c3dc630c6a90fabff2a2d7c4d12cb841d3f946d2e5e6fb2605e7edd84e3360308fe379dbf2b8dc2fa
   languageName: node
   linkType: hard
 
@@ -5849,7 +5806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-testing-library@npm:~7.6.6":
+"eslint-plugin-testing-library@npm:~7.6.8":
   version: 7.6.8
   resolution: "eslint-plugin-testing-library@npm:7.6.8"
   dependencies:
@@ -5889,56 +5846,6 @@ __metadata:
   version: 4.2.1
   resolution: "eslint-visitor-keys@npm:4.2.1"
   checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
-  languageName: node
-  linkType: hard
-
-"eslint@npm:~9.34.0":
-  version: 9.34.0
-  resolution: "eslint@npm:9.34.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.21.0"
-    "@eslint/config-helpers": "npm:^0.3.1"
-    "@eslint/core": "npm:^0.15.2"
-    "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.34.0"
-    "@eslint/plugin-kit": "npm:^0.3.5"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.4.0"
-    eslint-visitor-keys: "npm:^4.2.1"
-    espree: "npm:^10.4.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/ba3e54fa0c8ed23d062f91519afaae77fed922a6c4d76130b6cd32154bcb406aaea4b3c5ed88e0be40828c1d5b6921592f3947dbdc5e2043de6bd7aa341fe5ea
   languageName: node
   linkType: hard
 
@@ -6268,14 +6175,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "file-assets-bundle@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:~1.1.24"
+    "@terascope/eslint-config": "npm:~1.1.25"
     "@terascope/file-asset-apis": "npm:~1.1.2"
-    "@terascope/job-components": "npm:~1.12.2"
-    "@terascope/scripts": "npm:~1.21.5"
+    "@terascope/job-components": "npm:~1.12.3"
+    "@terascope/scripts": "npm:~1.21.6"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
     "@types/json2csv": "npm:~5.0.7"
-    "@types/node": "npm:~24.3.1"
+    "@types/node": "npm:~24.4.0"
     "@types/node-gzip": "npm:~1.1.3"
     "@types/semver": "npm:~7.7.1"
     eslint: "npm:~9.35.0"
@@ -6287,7 +6194,7 @@ __metadata:
     node-gzip: "npm:~1.1.2"
     node-notifier: "npm:~10.0.1"
     semver: "npm:~7.7.2"
-    teraslice-test-harness: "npm:~1.3.7"
+    teraslice-test-harness: "npm:~1.3.8"
     ts-jest: "npm:~29.4.1"
     typescript: "npm:~5.9.2"
   languageName: unknown
@@ -6337,7 +6244,7 @@ __metadata:
   resolution: "file@workspace:asset"
   dependencies:
     "@terascope/file-asset-apis": "npm:~1.1.2"
-    "@terascope/job-components": "npm:~1.12.2"
+    "@terascope/job-components": "npm:~1.12.3"
     csvtojson: "npm:~2.0.10"
     fs-extra: "npm:~11.3.1"
     json2csv: "npm:5.0.7"
@@ -6829,9 +6736,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:~14.4.7":
-  version: 14.4.7
-  resolution: "got@npm:14.4.7"
+"got@npm:~14.4.8":
+  version: 14.4.8
+  resolution: "got@npm:14.4.8"
   dependencies:
     "@sindresorhus/is": "npm:^7.0.1"
     "@szmarczak/http-timer": "npm:^5.0.1"
@@ -6844,7 +6751,7 @@ __metadata:
     p-cancelable: "npm:^4.0.1"
     responselike: "npm:^3.0.0"
     type-fest: "npm:^4.26.1"
-  checksum: 10c0/9b5b8dbc0642c78dbc64ab5ff6f12f6edab3e0cb80e89a3a69623a79ba3986f0ff0066a116fba47c0aacce4b0ba1eccf72f923f7fac13a31ce852bf9e2cb8f81
+  checksum: 10c0/7e8eb24dde86179e1163dc8c7cdac65b59764274f952fe3407252324a06912f77ebedf81cc17173120196558490d3f27525e0223ded5651c1937d25eb263867e
   languageName: node
   linkType: hard
 
@@ -7082,10 +6989,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-meta-resolve@npm:~4.1.0":
-  version: 4.1.0
-  resolution: "import-meta-resolve@npm:4.1.0"
-  checksum: 10c0/42f3284b0460635ddf105c4ad99c6716099c3ce76702602290ad5cbbcd295700cbc04e4bdf47bacf9e3f1a4cec2e1ff887dabc20458bef398f9de22ddff45ef5
+"import-meta-resolve@npm:~4.2.0":
+  version: 4.2.0
+  resolution: "import-meta-resolve@npm:4.2.0"
+  checksum: 10c0/3ee8aeecb61d19b49d2703987f977e9d1c7d4ba47db615a570eaa02fe414f40dfa63f7b953e842cbe8470d26df6371332bfcf21b2fd92b0112f9fea80dde2c4c
   languageName: node
   linkType: hard
 
@@ -7155,10 +7062,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-bigint@npm:~8.2.1":
-  version: 8.2.1
-  resolution: "ip-bigint@npm:8.2.1"
-  checksum: 10c0/5d19596b3374beade4daa278f9a35b7d1fc81c9fa4bf5ba8cc39dc3d198363b9ca6930025a70b3b37a46c5c514a87f2337c4ba2efeb0e514a5d233d7fe15495b
+"ip-bigint@npm:~8.2.2":
+  version: 8.2.2
+  resolution: "ip-bigint@npm:8.2.2"
+  checksum: 10c0/0be02e349c4a694e5bf64f3f5530d2cc159b59da14ca4a895cef1668334256c60bd0c3f219e06b1f49f6962de88e7ce7ba3610004d973dafb73779a9beea4464
   languageName: node
   linkType: hard
 
@@ -10836,15 +10743,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"teraslice-test-harness@npm:~1.3.7":
-  version: 1.3.7
-  resolution: "teraslice-test-harness@npm:1.3.7"
+"teraslice-test-harness@npm:~1.3.8":
+  version: 1.3.8
+  resolution: "teraslice-test-harness@npm:1.3.8"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.2.1"
-    "@terascope/job-components": "npm:~1.12.2"
+    "@terascope/job-components": "npm:~1.12.3"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.1"
-  checksum: 10c0/c1a88efddc4fb6c4b9817078a7389d4f809b3b95e9bb34fbcda093dcda622c6ab95cbbb6ce0085a9b0dccbc82352742c7c84c649f9b546122fb32522461d33d1
+  checksum: 10c0/b2ab469949d442314b624be12c4de28db2ca33686ad83ea16608ddfc70496da3d8e96fe51a1b2df19c79bd49a1a230b960bac41620b2e1e6085279ab235bec06
   languageName: node
   linkType: hard
 
@@ -11139,9 +11046,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:~0.28.11":
-  version: 0.28.12
-  resolution: "typedoc@npm:0.28.12"
+"typedoc@npm:~0.28.12":
+  version: 0.28.13
+  resolution: "typedoc@npm:0.28.13"
   dependencies:
     "@gerrit0/mini-shiki": "npm:^3.12.0"
     lunr: "npm:^2.3.9"
@@ -11152,22 +11059,22 @@ __metadata:
     typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10c0/b83a182df0887dce0a27df462e86e9ad771b3eff32eeef07b2b2424e57794050de540cd4667a640165518360fe47393cc92b55bc4ca861bd5746ed696df086d0
+  checksum: 10c0/f4815cb21a62fadbfeb6f5ad6405d3c819b6bcb20bd1e125c5b1a1a7c7bfabbd9dd67d742f767ce95283e99814a361b86bcc632e9ffa595e51e057778def4d57
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:~8.40.0":
-  version: 8.40.0
-  resolution: "typescript-eslint@npm:8.40.0"
+"typescript-eslint@npm:~8.43.0":
+  version: 8.43.0
+  resolution: "typescript-eslint@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.40.0"
-    "@typescript-eslint/parser": "npm:8.40.0"
-    "@typescript-eslint/typescript-estree": "npm:8.40.0"
-    "@typescript-eslint/utils": "npm:8.40.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.43.0"
+    "@typescript-eslint/parser": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
+    "@typescript-eslint/utils": "npm:8.43.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/b9bf9cbe13a89348ae2a13a7839238b1b058c1e188d9cc1028810c43f1b48cf256f5255ca94c38acf3cd5a405c918ad96d5b7f7a6ad3f82fa7429122a7883a83
+  checksum: 10c0/ee8429b16a5b7678136b8b2688bec03d11b5f1590895523ba9b8c6920c7a0876c9bf3bf0ff415df79e57c10ed48955cf183b727394b1c228ca75b5168fb466a1
   languageName: node
   linkType: hard
 
@@ -11240,6 +11147,13 @@ __metadata:
   version: 7.10.0
   resolution: "undici-types@npm:7.10.0"
   checksum: 10c0/8b00ce50e235fe3cc601307f148b5e8fb427092ee3b23e8118ec0a5d7f68eca8cee468c8fc9f15cbb2cf2a3797945ebceb1cbd9732306a1d00e0a9b6afa0f635
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.11.0":
+  version: 7.11.0
+  resolution: "undici-types@npm:7.11.0"
+  checksum: 10c0/24ff69baeaebc7d09f4dae68564df850b4ff561810148ff6c37d3fc64dd1460c55e59e604420495e73b1fb48594a1c98e69f6732086a24e01b88f2d926378af1
   languageName: node
   linkType: hard
 
@@ -11397,12 +11311,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:~11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
+"uuid@npm:~12.0.0":
+  version: 12.0.0
+  resolution: "uuid@npm:12.0.0"
   bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+    uuid: dist/bin/uuid
+  checksum: 10c0/242db6735d15a187a0d7f22576db02668f974ffc65d0806b23fe4237cbb0db3153442cb3082c7550784acb6272e5c6c931532916f9604bd814dfab1edf2dac40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following dependencies:

## File-Assets

- @terascope/job-components: `v1.12.3`

## Workspace

- @terascope/eslint-config: `v1.1.25`
- @terascope/job-components: `v1.12.3`
- @terascope/scripts: `v1.21.6`
- @types/node: `v24.4.0`
- teraslice-test-harness: `v1.3.8`

## @terascope/file-asset-apis

- @aws-sdk/client-s3: `v3.888.0`
- @smithy/node-http-handler: `v4.2.1`
- @terascope/utils: `v1.10.3`
- @terascope/scripts: `v1.21.6`