### PR TITLE
bundled deps updates 2025-10-14

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
         "@types/json2csv": "~5.0.7",
-        "@types/node": "~24.7.2",
+        "@types/node": "~24.8.0",
         "@types/node-gzip": "~1.1.3",
         "@types/semver": "~7.7.1",
         "eslint": "~9.37.0",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -21,8 +21,8 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "~3.908.0",
-        "@smithy/node-http-handler": "~4.4.1",
+        "@aws-sdk/client-s3": "~3.911.0",
+        "@smithy/node-http-handler": "~4.4.2",
         "@terascope/utils": "~1.10.4",
         "csvtojson": "~2.0.10",
         "fs-extra": "~11.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,494 +97,494 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:~3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/client-s3@npm:3.908.0"
+"@aws-sdk/client-s3@npm:~3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/client-s3@npm:3.911.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:5.2.0"
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/credential-provider-node": "npm:3.908.0"
-    "@aws-sdk/middleware-bucket-endpoint": "npm:3.901.0"
-    "@aws-sdk/middleware-expect-continue": "npm:3.901.0"
-    "@aws-sdk/middleware-flexible-checksums": "npm:3.908.0"
-    "@aws-sdk/middleware-host-header": "npm:3.901.0"
-    "@aws-sdk/middleware-location-constraint": "npm:3.901.0"
-    "@aws-sdk/middleware-logger": "npm:3.901.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.901.0"
-    "@aws-sdk/middleware-sdk-s3": "npm:3.908.0"
-    "@aws-sdk/middleware-ssec": "npm:3.901.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.908.0"
-    "@aws-sdk/region-config-resolver": "npm:3.901.0"
-    "@aws-sdk/signature-v4-multi-region": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@aws-sdk/util-endpoints": "npm:3.901.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.907.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.908.0"
-    "@aws-sdk/xml-builder": "npm:3.901.0"
-    "@smithy/config-resolver": "npm:^4.3.0"
-    "@smithy/core": "npm:^3.15.0"
-    "@smithy/eventstream-serde-browser": "npm:^4.2.0"
-    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.0"
-    "@smithy/eventstream-serde-node": "npm:^4.2.0"
-    "@smithy/fetch-http-handler": "npm:^5.3.1"
-    "@smithy/hash-blob-browser": "npm:^4.2.1"
-    "@smithy/hash-node": "npm:^4.2.0"
-    "@smithy/hash-stream-node": "npm:^4.2.0"
-    "@smithy/invalid-dependency": "npm:^4.2.0"
-    "@smithy/md5-js": "npm:^4.2.0"
-    "@smithy/middleware-content-length": "npm:^4.2.0"
-    "@smithy/middleware-endpoint": "npm:^4.3.1"
-    "@smithy/middleware-retry": "npm:^4.4.1"
-    "@smithy/middleware-serde": "npm:^4.2.0"
-    "@smithy/middleware-stack": "npm:^4.2.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/node-http-handler": "npm:^4.3.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/smithy-client": "npm:^4.7.1"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/url-parser": "npm:^4.2.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/credential-provider-node": "npm:3.911.0"
+    "@aws-sdk/middleware-bucket-endpoint": "npm:3.910.0"
+    "@aws-sdk/middleware-expect-continue": "npm:3.910.0"
+    "@aws-sdk/middleware-flexible-checksums": "npm:3.911.0"
+    "@aws-sdk/middleware-host-header": "npm:3.910.0"
+    "@aws-sdk/middleware-location-constraint": "npm:3.910.0"
+    "@aws-sdk/middleware-logger": "npm:3.910.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.910.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.911.0"
+    "@aws-sdk/middleware-ssec": "npm:3.910.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.911.0"
+    "@aws-sdk/region-config-resolver": "npm:3.910.0"
+    "@aws-sdk/signature-v4-multi-region": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/util-endpoints": "npm:3.910.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.910.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.911.0"
+    "@aws-sdk/xml-builder": "npm:3.911.0"
+    "@smithy/config-resolver": "npm:^4.3.2"
+    "@smithy/core": "npm:^3.16.1"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.2"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.2"
+    "@smithy/eventstream-serde-node": "npm:^4.2.2"
+    "@smithy/fetch-http-handler": "npm:^5.3.3"
+    "@smithy/hash-blob-browser": "npm:^4.2.3"
+    "@smithy/hash-node": "npm:^4.2.2"
+    "@smithy/hash-stream-node": "npm:^4.2.2"
+    "@smithy/invalid-dependency": "npm:^4.2.2"
+    "@smithy/md5-js": "npm:^4.2.2"
+    "@smithy/middleware-content-length": "npm:^4.2.2"
+    "@smithy/middleware-endpoint": "npm:^4.3.3"
+    "@smithy/middleware-retry": "npm:^4.4.3"
+    "@smithy/middleware-serde": "npm:^4.2.2"
+    "@smithy/middleware-stack": "npm:^4.2.2"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/node-http-handler": "npm:^4.4.1"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/smithy-client": "npm:^4.8.1"
+    "@smithy/types": "npm:^4.7.1"
+    "@smithy/url-parser": "npm:^4.2.2"
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-body-length-browser": "npm:^4.2.0"
     "@smithy/util-body-length-node": "npm:^4.2.1"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.0"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.1"
-    "@smithy/util-endpoints": "npm:^3.2.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
-    "@smithy/util-retry": "npm:^4.2.0"
-    "@smithy/util-stream": "npm:^4.5.0"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.2"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.3"
+    "@smithy/util-endpoints": "npm:^3.2.2"
+    "@smithy/util-middleware": "npm:^4.2.2"
+    "@smithy/util-retry": "npm:^4.2.2"
+    "@smithy/util-stream": "npm:^4.5.2"
     "@smithy/util-utf8": "npm:^4.2.0"
-    "@smithy/util-waiter": "npm:^4.2.0"
+    "@smithy/util-waiter": "npm:^4.2.2"
     "@smithy/uuid": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/219b618387eaf10c1da9f7b774d44bd68225ae3b7cd3c2bd297e66094326c979e8a26d4788cab670f19f48366fd0384480d6939e799fba445ad156e937a142be
+  checksum: 10c0/8f30f2a77543e5521f4dc6f221fc6e6e6b9229b0aacdecfbc0821f37bb532db6059e3591777efbdf7b076ffb8326e994546227d118fee2b27ffca46529b84f09
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/client-sso@npm:3.908.0"
+"@aws-sdk/client-sso@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/client-sso@npm:3.911.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/middleware-host-header": "npm:3.901.0"
-    "@aws-sdk/middleware-logger": "npm:3.901.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.901.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.908.0"
-    "@aws-sdk/region-config-resolver": "npm:3.901.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@aws-sdk/util-endpoints": "npm:3.901.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.907.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.908.0"
-    "@smithy/config-resolver": "npm:^4.3.0"
-    "@smithy/core": "npm:^3.15.0"
-    "@smithy/fetch-http-handler": "npm:^5.3.1"
-    "@smithy/hash-node": "npm:^4.2.0"
-    "@smithy/invalid-dependency": "npm:^4.2.0"
-    "@smithy/middleware-content-length": "npm:^4.2.0"
-    "@smithy/middleware-endpoint": "npm:^4.3.1"
-    "@smithy/middleware-retry": "npm:^4.4.1"
-    "@smithy/middleware-serde": "npm:^4.2.0"
-    "@smithy/middleware-stack": "npm:^4.2.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/node-http-handler": "npm:^4.3.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/smithy-client": "npm:^4.7.1"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/url-parser": "npm:^4.2.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/middleware-host-header": "npm:3.910.0"
+    "@aws-sdk/middleware-logger": "npm:3.910.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.910.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.911.0"
+    "@aws-sdk/region-config-resolver": "npm:3.910.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/util-endpoints": "npm:3.910.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.910.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.911.0"
+    "@smithy/config-resolver": "npm:^4.3.2"
+    "@smithy/core": "npm:^3.16.1"
+    "@smithy/fetch-http-handler": "npm:^5.3.3"
+    "@smithy/hash-node": "npm:^4.2.2"
+    "@smithy/invalid-dependency": "npm:^4.2.2"
+    "@smithy/middleware-content-length": "npm:^4.2.2"
+    "@smithy/middleware-endpoint": "npm:^4.3.3"
+    "@smithy/middleware-retry": "npm:^4.4.3"
+    "@smithy/middleware-serde": "npm:^4.2.2"
+    "@smithy/middleware-stack": "npm:^4.2.2"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/node-http-handler": "npm:^4.4.1"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/smithy-client": "npm:^4.8.1"
+    "@smithy/types": "npm:^4.7.1"
+    "@smithy/url-parser": "npm:^4.2.2"
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-body-length-browser": "npm:^4.2.0"
     "@smithy/util-body-length-node": "npm:^4.2.1"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.0"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.1"
-    "@smithy/util-endpoints": "npm:^3.2.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
-    "@smithy/util-retry": "npm:^4.2.0"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.2"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.3"
+    "@smithy/util-endpoints": "npm:^3.2.2"
+    "@smithy/util-middleware": "npm:^4.2.2"
+    "@smithy/util-retry": "npm:^4.2.2"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/bfd3525f394ee87ddd1b0cc92e334f00e21a5b31f3fd85ee09d2797190cdbd70e96bf1f88dd2a13252b0f704a633c60f90779b7e8ee7cbf03b20bc86cb287d0b
+  checksum: 10c0/ef07589cf448bb30136e015d6ea594aa84704b45234fc984d0d9824a2d2f2f7595d14090766b92f46b116b39f41071b083f41d2e95a0eb4ebf8fbc39105903fd
   languageName: node
   linkType: hard
 
-"@aws-sdk/core@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/core@npm:3.908.0"
+"@aws-sdk/core@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/core@npm:3.911.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@aws-sdk/xml-builder": "npm:3.901.0"
-    "@smithy/core": "npm:^3.15.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/signature-v4": "npm:^5.3.0"
-    "@smithy/smithy-client": "npm:^4.7.1"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/xml-builder": "npm:3.911.0"
+    "@smithy/core": "npm:^3.16.1"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/signature-v4": "npm:^5.3.2"
+    "@smithy/smithy-client": "npm:^4.8.1"
+    "@smithy/types": "npm:^4.7.1"
     "@smithy/util-base64": "npm:^4.3.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
+    "@smithy/util-middleware": "npm:^4.2.2"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/fa5ab0d33a30155df388133f8298293d08360313703bfa7a15a077866760adfe97d636824a6866dc5cae90655f8e59b6ce93460ce72911e133ab2e48c4cc746d
+  checksum: 10c0/438e7c7a5d75d970650c31d76d81a8d4152a779df0b2d757b7a4b110f31104989ce878f260b843ffa083f6dd3cef2e58304884373c9d750a4bad60e9a669a50f
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.908.0"
+"@aws-sdk/credential-provider-env@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.911.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d9e6630d28cf1374b334e0cf6a6a8331352bddcf5b6305d1b32e6d07716a835cce258927cb82d9cc309f3a67e810a80c4458f53540f6f1185382e023db8498f5
+  checksum: 10c0/09e9b080fdf63bb48575e9ef9e233ad5fcc895cd727fd3db2d45a012d188cb3612bc0e4b04fee1cf302f14c1a5fcc01b32e3e154263853bddec0a7f72a259707
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-http@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/credential-provider-http@npm:3.908.0"
+"@aws-sdk/credential-provider-http@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.911.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/fetch-http-handler": "npm:^5.3.1"
-    "@smithy/node-http-handler": "npm:^4.3.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/smithy-client": "npm:^4.7.1"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/util-stream": "npm:^4.5.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/fetch-http-handler": "npm:^5.3.3"
+    "@smithy/node-http-handler": "npm:^4.4.1"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/smithy-client": "npm:^4.8.1"
+    "@smithy/types": "npm:^4.7.1"
+    "@smithy/util-stream": "npm:^4.5.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9624570866310a663199bde3deb9d91c748cd177319f06dfafa32521d820e7aa1c2aa5ad421993a14de5ed2e6f55dd89e8ac406b0c73f040444c1c9e9164634c
+  checksum: 10c0/9bfe10fb49989e22db9b5fffcade6195e1fe9633d9eb8baf92b8e7e5a985f2a34df185ad42e05c66d8ace37851284c576ebc6e601e27cee5b8f833741567fa73
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.908.0"
+"@aws-sdk/credential-provider-ini@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.911.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/credential-provider-env": "npm:3.908.0"
-    "@aws-sdk/credential-provider-http": "npm:3.908.0"
-    "@aws-sdk/credential-provider-process": "npm:3.908.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.908.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.908.0"
-    "@aws-sdk/nested-clients": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/credential-provider-imds": "npm:^4.2.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/credential-provider-env": "npm:3.911.0"
+    "@aws-sdk/credential-provider-http": "npm:3.911.0"
+    "@aws-sdk/credential-provider-process": "npm:3.911.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.911.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.911.0"
+    "@aws-sdk/nested-clients": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/credential-provider-imds": "npm:^4.2.2"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/baa78040ca5174ed2db4b2b2f7df5b7e01344bcb4a0ffb7937fdb3568ef5c206c9d3dfa536fa49b44705c33b1e685584c2267c745c0c557dd80a62290d01a511
+  checksum: 10c0/fa6b13fdbb38c59ea3dd171a46b997ab0712a5c6f4da5c78d2e6ca87ea21257e98a93313b0b34b16777e4d34f5fba6f0a0f510707348528be8d60e46272fb79c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.908.0"
+"@aws-sdk/credential-provider-node@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.911.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.908.0"
-    "@aws-sdk/credential-provider-http": "npm:3.908.0"
-    "@aws-sdk/credential-provider-ini": "npm:3.908.0"
-    "@aws-sdk/credential-provider-process": "npm:3.908.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.908.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/credential-provider-imds": "npm:^4.2.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/credential-provider-env": "npm:3.911.0"
+    "@aws-sdk/credential-provider-http": "npm:3.911.0"
+    "@aws-sdk/credential-provider-ini": "npm:3.911.0"
+    "@aws-sdk/credential-provider-process": "npm:3.911.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.911.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/credential-provider-imds": "npm:^4.2.2"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/32a32574aaee9e5968af6e81016c86630f973af30d93dd219d000a5208dd8ecce271e4eb782d2cb5a8dc6b334cd207fc1742db5cdd01e2bd90259cff54d12d27
+  checksum: 10c0/c3365e878f244ca7abbee275875c53c3cf5859ab9d6b5d4e8bd927d1f58b8eb475578d02ebcb3b686db987fa301d6d572f5bf5816d7cc9b75d72eca908bc14fb
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.908.0"
+"@aws-sdk/credential-provider-process@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.911.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/be167dbbd903d9318f195009c9c389f5e00ba167d5d3ba739557873c3b5eb7b384e3c590a50a291a49c97277e498c110c68300aa5f030f2e25269e48e8bd6905
+  checksum: 10c0/02563d2bd90b2a3b89d2ed338ea9dd2bb6a8f7585f7a77b4c3fc040f2d84e20b28196c2a61fc2b1298c0184a6a7ead22b7d5d87f8949c5d96057d638f06dd858
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.908.0"
+"@aws-sdk/credential-provider-sso@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.911.0"
   dependencies:
-    "@aws-sdk/client-sso": "npm:3.908.0"
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/token-providers": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/client-sso": "npm:3.911.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/token-providers": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/db8c49140bb16cdf904e46296e238403c44d0cecd1f3fe7d1d36453891eb63c39c0c9d5fee4655d3f94f59ac9b28e3eb33beb360f2c399ef575ca8f949f0923a
+  checksum: 10c0/9f590b512ae089ed072b637a341696a498dea0665d75440845f6b33e87b63d2719f2d06fe9a6ec8e40b02e18dbe054d2d4c5a444a8ea6c3ebd9d028825a8e881
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.908.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.911.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/nested-clients": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/nested-clients": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7eb01e9c035a41b3b3694643d665d7a71e683cceb239e6e3a0a9844c5a664a34b790a820eed4ac3c0dd9d6eb9e0092ebd0a9d79c6529189d68c81ce9d53cdd0e
+  checksum: 10c0/bc7a5581d202dcc7d3d5d5d4295dc8408dd35eb7b630c38a3e73e4465500f5746901664207cf0e8313bc237fa319966f6ad29d1555617ad8f7832b6128cc8073
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.901.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
+    "@aws-sdk/types": "npm:3.910.0"
     "@aws-sdk/util-arn-parser": "npm:3.893.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/types": "npm:^4.7.1"
     "@smithy/util-config-provider": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d3675d7468e4c268854bfcd945683bd87e55f194ff19379977a9df77591f5ab57258836cceed5aefad33ae783e5dd0120d8d2a983b1acdcae90058a6fc572d41
+  checksum: 10c0/32154bd1870c691d5071e5275a17ba2ea542bece2bf2da8464389c95358f1631d199af3bba25958098f04bf9dc11a569fafb2bb96d452718170abab86597300b
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.901.0"
+"@aws-sdk/middleware-expect-continue@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/534714439b8f62e9b8ac0fb75d40b2cb51c4c69745ca80a2fc79cd927d492eba5748f0a0a8aacd5a0f11f621f718756504a5792b2445d3643b4aa5ee7df50666
+  checksum: 10c0/1e8b9426e8b1a7f0db82faded10ac8047310f52224468bb00c7271a172fe645518b46a92be3b7cfdf757179f5ee43d53f69c81be303c5f8851ae330028b5b20a
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-flexible-checksums@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.908.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.911.0"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
     "@aws-crypto/crc32c": "npm:5.2.0"
     "@aws-crypto/util": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
     "@smithy/is-array-buffer": "npm:^4.2.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
-    "@smithy/util-stream": "npm:^4.5.0"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/types": "npm:^4.7.1"
+    "@smithy/util-middleware": "npm:^4.2.2"
+    "@smithy/util-stream": "npm:^4.5.2"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/b095aa66ff629559c4f6f8a3db79ad55f06de2cd449b186249fa7785d7f081a96195cb95c68835113b72e74552c6411eebc8df491c2f5f272af946e9d1461a2c
+  checksum: 10c0/706dcd0276be6a98d7d0bce671efb27c43921f909535fdf7c49934ba881e954ddfe763fdd428b1b22291ae1476a3db8442a70fef66e3fe3baf7caa23a962bd9b
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.901.0"
+"@aws-sdk/middleware-host-header@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/f36cffb33532df97f7480a9a0705a0d3e874861b12e10d3b1713ef4f830e1d17e8568c3baff1c4c05ad681115af6e8e4f84d828a9834a9df8b6127fbc5af5f48
+  checksum: 10c0/bfd348a15b855a89a46a5c3cc18dbca94eda541847c3260b2d66b8c84440976cd527831bab7adaf3f6bc68fb9b61b885b69762dee3830cb960a2a18a8c517482
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-location-constraint@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.901.0"
+"@aws-sdk/middleware-location-constraint@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a1e57365274bf89dc1b74e70be377de819251ac529d140442401bc7f968021a429ae0a77edd68cbac868905a7ded7a9d09aaedac89117f15ad2c01e1bed91fea
+  checksum: 10c0/91d06ca54012047048396ccdf1eb74477ae7d90feb28243f2e0a88df120e6c403b63c9c42b170114be4d994c089bbb1023b78db4cd6251ad978714ed8b297bed
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.901.0"
+"@aws-sdk/middleware-logger@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/6ad444c2d791d2f8158c1e5262cdc12591a41164f63c660eb8874d4f915f007001d152deb426874ff4d4b1326d5e6b18bbdfe3087fa6fdc9ce7c88ed6bb75997
+  checksum: 10c0/33d0ec8c067701e8fb80f792ec4208decb0eb61502fd34377976bcd0aea5ee2c554a0861b3f42547a6a11abfe7ca5324c419d87dbe88def282b9ce4da2edb068
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.901.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
+    "@aws-sdk/types": "npm:3.910.0"
     "@aws/lambda-invoke-store": "npm:^0.0.1"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/428d2da0d4583c8b33e5c10153b5cfebf572962a11df7501c35b5361b9e39fc9ab7b8778484a8f29d521f1ba37865bf0a441650de7c539e707714d4321c13272
+  checksum: 10c0/bdf27349e500c8abffc67c5ed017dad8749b5a007d1e1da0fea7f12cb5e85a6255e28811e517566454a1a6a201fea6fe94cb8e90d4f8d8023cbcbf412afddcdd
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.908.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.911.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
     "@aws-sdk/util-arn-parser": "npm:3.893.0"
-    "@smithy/core": "npm:^3.15.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/signature-v4": "npm:^5.3.0"
-    "@smithy/smithy-client": "npm:^4.7.1"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/core": "npm:^3.16.1"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/signature-v4": "npm:^5.3.2"
+    "@smithy/smithy-client": "npm:^4.8.1"
+    "@smithy/types": "npm:^4.7.1"
     "@smithy/util-config-provider": "npm:^4.2.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
-    "@smithy/util-stream": "npm:^4.5.0"
+    "@smithy/util-middleware": "npm:^4.2.2"
+    "@smithy/util-stream": "npm:^4.5.2"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/de8b600bb1ae546912c4f70c10d52c5d17e793a9e455649d0ebe42d8f56563e0b4aaef15890da423086b9aaa824e2e209d7e3b476e9ad47826f7fa634bb6225f
+  checksum: 10c0/5143427a345ff842c1fd83ea198f8456d928221b5b8f9a9b698cfda0dbc5cd4b3bf38cd9194faf98a89af9ebbd53199d0712944b8fefab905378bc8899d5206c
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-ssec@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.901.0"
+"@aws-sdk/middleware-ssec@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/6748ba6674d1dcf48c970e67d477127924c2ae1c8026310b78d54221d3fbd5d5795f690119583cb2207e00bcc91875df5058d83763a37d311dd2ec1bba0367ce
+  checksum: 10c0/2156df7de3e63d426bc8fdc018298ae8dc6bcff55f9a21365de71142b0c61266f5e65657757a8815662f1b2a6d5c5a78e9b970bf4315907e6d7888059da0526a
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.908.0"
+"@aws-sdk/middleware-user-agent@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.911.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@aws-sdk/util-endpoints": "npm:3.901.0"
-    "@smithy/core": "npm:^3.15.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/util-endpoints": "npm:3.910.0"
+    "@smithy/core": "npm:^3.16.1"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/0ff8ee148d1b332a4508727ce0449f377d4bf9c4cdb724df20e6da4211e074acc08cb1f29cfb5c29140da80c5b583ab74df3cf84f71fd8f829cea265f8b00112
+  checksum: 10c0/4c8084ef88e5b62da3ac6dc0f28da12bea2b94a4962f95012253ee4c1ddb271e53448f7aa72c4a1fb5640f8a6621ec84713ce385943486c8e093b55c64ba6599
   languageName: node
   linkType: hard
 
-"@aws-sdk/nested-clients@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/nested-clients@npm:3.908.0"
+"@aws-sdk/nested-clients@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/nested-clients@npm:3.911.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/middleware-host-header": "npm:3.901.0"
-    "@aws-sdk/middleware-logger": "npm:3.901.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.901.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.908.0"
-    "@aws-sdk/region-config-resolver": "npm:3.901.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@aws-sdk/util-endpoints": "npm:3.901.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.907.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.908.0"
-    "@smithy/config-resolver": "npm:^4.3.0"
-    "@smithy/core": "npm:^3.15.0"
-    "@smithy/fetch-http-handler": "npm:^5.3.1"
-    "@smithy/hash-node": "npm:^4.2.0"
-    "@smithy/invalid-dependency": "npm:^4.2.0"
-    "@smithy/middleware-content-length": "npm:^4.2.0"
-    "@smithy/middleware-endpoint": "npm:^4.3.1"
-    "@smithy/middleware-retry": "npm:^4.4.1"
-    "@smithy/middleware-serde": "npm:^4.2.0"
-    "@smithy/middleware-stack": "npm:^4.2.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/node-http-handler": "npm:^4.3.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/smithy-client": "npm:^4.7.1"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/url-parser": "npm:^4.2.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/middleware-host-header": "npm:3.910.0"
+    "@aws-sdk/middleware-logger": "npm:3.910.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.910.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.911.0"
+    "@aws-sdk/region-config-resolver": "npm:3.910.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/util-endpoints": "npm:3.910.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.910.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.911.0"
+    "@smithy/config-resolver": "npm:^4.3.2"
+    "@smithy/core": "npm:^3.16.1"
+    "@smithy/fetch-http-handler": "npm:^5.3.3"
+    "@smithy/hash-node": "npm:^4.2.2"
+    "@smithy/invalid-dependency": "npm:^4.2.2"
+    "@smithy/middleware-content-length": "npm:^4.2.2"
+    "@smithy/middleware-endpoint": "npm:^4.3.3"
+    "@smithy/middleware-retry": "npm:^4.4.3"
+    "@smithy/middleware-serde": "npm:^4.2.2"
+    "@smithy/middleware-stack": "npm:^4.2.2"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/node-http-handler": "npm:^4.4.1"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/smithy-client": "npm:^4.8.1"
+    "@smithy/types": "npm:^4.7.1"
+    "@smithy/url-parser": "npm:^4.2.2"
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-body-length-browser": "npm:^4.2.0"
     "@smithy/util-body-length-node": "npm:^4.2.1"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.0"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.1"
-    "@smithy/util-endpoints": "npm:^3.2.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
-    "@smithy/util-retry": "npm:^4.2.0"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.2"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.3"
+    "@smithy/util-endpoints": "npm:^3.2.2"
+    "@smithy/util-middleware": "npm:^4.2.2"
+    "@smithy/util-retry": "npm:^4.2.2"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/59dd60269a978ae8b26e9faa6491f45646b9b4fdbb933d2256ff2d539ae60b960ec94ff62181f28a409317c429e6ec182e9f5558c455ee45f598175b5b8d05fd
+  checksum: 10c0/d1c993ad22f7e58d10d2fccade5f4e9d12b04f8304a6b06615c088f827105b75c75e14be4698d120038d6f7d6e7244204c15813a5c2d5f87d9ef6e347fc320ec
   languageName: node
   linkType: hard
 
-"@aws-sdk/region-config-resolver@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/region-config-resolver@npm:3.901.0"
+"@aws-sdk/region-config-resolver@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.7.1"
     "@smithy/util-config-provider": "npm:^4.2.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
+    "@smithy/util-middleware": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a01f85908e38ea43cd6e69dcb2c33916cf2a8de3e7f0baa004e218317e3f331829746f17bcc2f79c4fc7ae7c9ff0716b30986618bd776800ee8d1b535f3849d7
+  checksum: 10c0/03bc2172d0c3b134cbb496e8546606a8821fc4f0272ea03aadfd653b29956ddbbfa2ad3e12b7937d3e98d7b0f92e8fedb2af6559f2389c2d1d4ffc37bb55c5b0
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.908.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.911.0"
   dependencies:
-    "@aws-sdk/middleware-sdk-s3": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/signature-v4": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/protocol-http": "npm:^5.3.2"
+    "@smithy/signature-v4": "npm:^5.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7080fa36ba6ced905bca9c2aa8eb74d25ed2c59a4559fc500063af03b9ad128e6ff27c729efb84ed5089fae42dcf1b246d4e9ec672028849061db58183009dd2
+  checksum: 10c0/c9b619a8f8f49b7bf5e2d10518e3e9d66ceaaa6a991f18bfcc6dc23877984195d30f4d8adbc66c85b999a77dc66a4bbaa9c9b35c5e74e8f855c68b27bc526b49
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/token-providers@npm:3.908.0"
+"@aws-sdk/token-providers@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/token-providers@npm:3.911.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.908.0"
-    "@aws-sdk/nested-clients": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/core": "npm:3.911.0"
+    "@aws-sdk/nested-clients": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/property-provider": "npm:^4.2.2"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/432e70c9b2ca20c4a3a501fd96ff7c31ce9099eb448fe6ecec13171efbe420e116a73450885106c65712a2670be52091ba5558e464385ccbf94d80acb25e260c
+  checksum: 10c0/287a1777c8885a6e0a2af0856356e3fc063c1d8d28abda3602b862d0aa4a56593751d4e2b820cb0588432b890d68f432b00720cdf4e04fc04a6c79cc9f9c3439
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/types@npm:3.901.0"
+"@aws-sdk/types@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/types@npm:3.910.0"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/38f1b7dac82b0e53faf764d0e741e32385c1e022b67c73d601fe3fd0f66d1a75d72dddd8f41dde89944441df766217f00a451a6d95caa256bebe08891206d949
+  checksum: 10c0/b91c035d68999dfef31ffb81f0f6dea6d9a763339293d4267975dc9bc0f946d39d48fa51dbe643360d8643686e6ccce783f2ae1e3dfabd4d470bb8834c1186d3
   languageName: node
   linkType: hard
 
@@ -607,16 +607,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-endpoints@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.901.0"
+"@aws-sdk/util-endpoints@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/url-parser": "npm:^4.2.0"
-    "@smithy/util-endpoints": "npm:^3.2.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/types": "npm:^4.7.1"
+    "@smithy/url-parser": "npm:^4.2.2"
+    "@smithy/util-endpoints": "npm:^3.2.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ae6a2b15975e1b4e36211c30ff7ea2ac080bb5add13a7e5181b348bc393a74f82b6c5afb998c8dde9aedfe97eae23e0ce64da79cbd2b4061c594d1bd3d9d4a65
+  checksum: 10c0/1944c8ff7fd50ef6e018a27c378ae0eba7672900827cbc2b1604d04ce08ec2a74dea11eb3a9ba63a00e4083206be93e9a90aaa424f841e5f5c55888cf0e07073
   languageName: node
   linkType: hard
 
@@ -629,44 +629,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.907.0":
-  version: 3.907.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.907.0"
+"@aws-sdk/util-user-agent-browser@npm:3.910.0":
+  version: 3.910.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.910.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/types": "npm:^4.7.1"
     bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/581e8bdf2391e3ce0725b7660ad10bcfafb5f0ab90c4b76a8a906593d85c1b9fcb3f1b525610279e05ee85805f737c14e24e4c5d364acbece52d333d8e51f440
+  checksum: 10c0/7f331a95df724548198a076f560cb1a7491c4b87dc76b2eea623ef6acc2c4b186e50a393336a26ecf83fadb9375c9eb668e5b5bc154adcf3e17ecf7ae0f89cc0
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.908.0":
-  version: 3.908.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.908.0"
+"@aws-sdk/util-user-agent-node@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.911.0"
   dependencies:
-    "@aws-sdk/middleware-user-agent": "npm:3.908.0"
-    "@aws-sdk/types": "npm:3.901.0"
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.911.0"
+    "@aws-sdk/types": "npm:3.910.0"
+    "@smithy/node-config-provider": "npm:^4.3.2"
+    "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 10c0/3cf41f441337513574f350176ca39dc6f4b3c3263605c741142ff08c1d1c5ca3c26958bb732bd6e20aceb820d844b6ab246435dfa6ec481476d8930ffe4225c9
+  checksum: 10c0/e7ceaa43633aa27f7d3239fc1006d844a23ab720635c2898f0da5024588feb77a1c77cd3142d1450d751b93ee4ae404756c7364230b2ac7b4ef473372ada1378
   languageName: node
   linkType: hard
 
-"@aws-sdk/xml-builder@npm:3.901.0":
-  version: 3.901.0
-  resolution: "@aws-sdk/xml-builder@npm:3.901.0"
+"@aws-sdk/xml-builder@npm:3.911.0":
+  version: 3.911.0
+  resolution: "@aws-sdk/xml-builder@npm:3.911.0"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.7.1"
     fast-xml-parser: "npm:5.2.5"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/407af75a7ea2d2d27021d54bfb59d53b3fd2f068234ade97b3b158ff6f753f85a0effa0d765c48b377a5b73194e1908f68f2959fb77e871e9137a8650b2caeef
+  checksum: 10c0/174aa60f5be883954b33082af65a20238a64bd69c4983ee7617786b77624325ddd8ae844b7a59e5d3bb92d33519e5bb9a6d626ce2fa547bd60455ba65867ddda
   languageName: node
   linkType: hard
 
@@ -2134,16 +2134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/abort-controller@npm:4.2.0"
-  dependencies:
-    "@smithy/types": "npm:^4.6.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/de11e4491f3042f9d3738c0bfccdcbcfa01468a90ff745ec59a26c405772f590e675f3fa7e4cfcde9165891348bb31ee434290717e8aaa90e1c131668cdcf008
-  languageName: node
-  linkType: hard
-
 "@smithy/abort-controller@npm:^4.2.2":
   version: 4.2.2
   resolution: "@smithy/abort-controller@npm:4.2.2"
@@ -2151,6 +2141,16 @@ __metadata:
     "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/eb0428d3f1cde2f7689b84f725db23d1160c493addabd00a48f1589df6dad9cf69c88050017bdaf57dc37f81ce8b390673aebdf358195598b63a8481f89056c5
+  languageName: node
+  linkType: hard
+
+"@smithy/abort-controller@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/abort-controller@npm:4.2.3"
+  dependencies:
+    "@smithy/types": "npm:^4.8.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ddb1333f85df6e61e2b4ab9d7ae8c0135fa44e7d81703d18accdefb1c280c00c8f339e157e48ca8a19fbabe3d73e728df8dfca732418268961d6ba93c7b0fb7e
   languageName: node
   linkType: hard
 
@@ -2173,19 +2173,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@smithy/config-resolver@npm:4.3.0"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/util-config-provider": "npm:^4.2.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/6847d620e946b84bcc35070e21db1d54cdd5a65701792552c706926b3db4fae77a9c1c54326bf631e9741e0586fabef371ead01c6a268c6cd44eaf7601915cde
-  languageName: node
-  linkType: hard
-
 "@smithy/config-resolver@npm:^4.3.2":
   version: 4.3.2
   resolution: "@smithy/config-resolver@npm:4.3.2"
@@ -2199,7 +2186,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^3.15.0, @smithy/core@npm:^3.16.1":
+"@smithy/config-resolver@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "@smithy/config-resolver@npm:4.3.3"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-config-provider": "npm:^4.2.0"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/297e16ebd901b6f22e22294806bc5e574e38cef0ff9ec2c03e5dd333883a108fc452a73d567f1dcad690d16337d7c726ba7e92c6b4e086712b6fd966f7e3c0b7
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^3.16.1":
   version: 3.16.1
   resolution: "@smithy/core@npm:3.16.1"
   dependencies:
@@ -2217,16 +2217,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/credential-provider-imds@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/credential-provider-imds@npm:4.2.0"
+"@smithy/core@npm:^3.17.0":
+  version: 3.17.0
+  resolution: "@smithy/core@npm:3.17.0"
   dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/url-parser": "npm:^4.2.0"
+    "@smithy/middleware-serde": "npm:^4.2.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-base64": "npm:^4.3.0"
+    "@smithy/util-body-length-browser": "npm:^4.2.0"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    "@smithy/util-stream": "npm:^4.5.3"
+    "@smithy/util-utf8": "npm:^4.2.0"
+    "@smithy/uuid": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d8d4127e0f0d991c72105213a75bf9e1249a59ee88c733ca1a5ec50ce99976a69ff00a4d6c0040b4330ffd94b6a2a40f0e0ac57dfb384512120280bce2267707
+  checksum: 10c0/3e7b0dfeac4b591b8caf3dd4ae68271b807044d2b8f22c5d97c6a10d1c27a15d329a5130d19cf416b60f4cdcbe46fad5491e419049e030629231002feef75846
   languageName: node
   linkType: hard
 
@@ -2243,62 +2248,75 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-codec@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/eventstream-codec@npm:4.2.0"
+"@smithy/credential-provider-imds@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/credential-provider-imds@npm:4.2.3"
+  dependencies:
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/url-parser": "npm:^4.2.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9ea3eb9f80779180f50e2b5f68fac66f4f144b14d10419e411fcf3d44576be148af5795dde6951816784352d58e6950a0c8b45830f8f1fae9d98ffdf00ba8479
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-codec@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/eventstream-codec@npm:4.2.3"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     "@smithy/util-hex-encoding": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/cfd4123a6103a0901a68c6b9844d34ab904ff7b5e4b856603564415202b400f49dc8fc6a2b42b91506fb08f320db615b6681573f839fdcf407f9560467c36a2a
+  checksum: 10c0/3ee59573ccbd90b063d818df9498c08384319a71aeb45b25b8dfe9292773cdb6c073b6acf5241deecca35991d8a961df04de9a11c8aff5bc900194b9153c1c01
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/eventstream-serde-browser@npm:4.2.0"
+"@smithy/eventstream-serde-browser@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/eventstream-serde-browser@npm:4.2.3"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/eventstream-serde-universal": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/53d20be86239ec5315c88d7ded387e797c53dc92e53be86891f28830de5df09d99259ad0f704c935636d53ac750f81a43380ab3b05cad5cba718bf8ad20c8cc9
+  checksum: 10c0/8b8c957c78f941a34cb8324f9ca0902424e75fe4eef66542296903f91bf3637dedc8ce2e0ada8941df2a0a73bfc379e1b855dc46e940ec55399a3b360a0cd5f0
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.3.0"
+"@smithy/eventstream-serde-config-resolver@npm:^4.3.2":
+  version: 4.3.3
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.3.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7d81c8ed9d5981ca0c7c9f25655f88f3a25b865bea03f87236aaed333439a6de16c0e6e8959a3513f6503d84f192fa4656dcbf385dc406c28cb0105e18d44149
+  checksum: 10c0/2f90d12bca32d561cb28161ccedb0e72e41e0bed547ae84c4d42d1e3e250327386da0b7906745b5dfcee5195cd5b7a90470f2446ebc4471b3c9f5f28adcb4a09
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-node@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/eventstream-serde-node@npm:4.2.0"
+"@smithy/eventstream-serde-node@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/eventstream-serde-node@npm:4.2.3"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/eventstream-serde-universal": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/862044bd95fc57a4e64e672c476d7902f63352fd5ed39588480bea85ea95da3d19c0f0eba61ae3af0ff452834948759f7897768e68c242e5a8b6c754a5d50821
+  checksum: 10c0/821960a2dfa7a50060d89097c6204fedea724f1888c7cc128f554202fac7874d2bcfb56b9737596471f72e18537d0a1788da2bb5d7df0a5c28b43fb1aa847cf8
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-universal@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/eventstream-serde-universal@npm:4.2.0"
+"@smithy/eventstream-serde-universal@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/eventstream-serde-universal@npm:4.2.3"
   dependencies:
-    "@smithy/eventstream-codec": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/eventstream-codec": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/378a4c07fbeefa413a9cf1446099d131a067592b7c823d63e5096fa475d3e3e4db7cecc80a94b601ffcd4bc23eda60fccac530feb184679d6b286f218e781580
+  checksum: 10c0/52ad09c0150d8102a4f96eae58e703c79613258329626b932e6b1259665182f2c8ee455d68b92bdd5f48bab10c91f37b96befe121077697d10edbc326b83c8cd
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^5.3.1, @smithy/fetch-http-handler@npm:^5.3.3":
+"@smithy/fetch-http-handler@npm:^5.3.3":
   version: 5.3.3
   resolution: "@smithy/fetch-http-handler@npm:5.3.3"
   dependencies:
@@ -2311,48 +2329,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/hash-blob-browser@npm:^4.2.1":
-  version: 4.2.3
-  resolution: "@smithy/hash-blob-browser@npm:4.2.3"
+"@smithy/fetch-http-handler@npm:^5.3.4":
+  version: 5.3.4
+  resolution: "@smithy/fetch-http-handler@npm:5.3.4"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/querystring-builder": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-base64": "npm:^4.3.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/93ab064fbdc66021975abf070544739d428be79a5c349ada84ca2eac9c8dd23dc1aacc5a13c50d1a0043a91062291659471645a029700a2e1e0ce59b0baba5a0
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-blob-browser@npm:^4.2.3":
+  version: 4.2.4
+  resolution: "@smithy/hash-blob-browser@npm:4.2.4"
   dependencies:
     "@smithy/chunked-blob-reader": "npm:^5.2.0"
     "@smithy/chunked-blob-reader-native": "npm:^4.2.1"
-    "@smithy/types": "npm:^4.7.1"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d0f8fcc2036f0f3dd1c02ba63d9c8c14402b339fddb962e8e030e6e6f62f75bcb73c8d623efe74de423a2a2178865ecf8920d2778d13b67054a1d538509b1837
+  checksum: 10c0/7c9ce6d103c0589b72dcd929bc146c7a843ab090cac2722264d26c910dc3b59e3b69c7ee9254dac8b6836c0a5cb83b8f31a0cbec2e0252d36d58bdd1e93e7964
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/hash-node@npm:4.2.0"
+"@smithy/hash-node@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/hash-node@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     "@smithy/util-buffer-from": "npm:^4.2.0"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/98156506ae037d4e224b7be0c63606a04b8884b2a0309fc48c7a0bdc87025e2347a71577c3cdc73f76b776dbf09526fde3fa9d459c5f7caf6ff5f2d9258cec2e
+  checksum: 10c0/8e2945ad4e7dc4e6ef24afea4532a29e79ff787c670085079e9441951ec4a0ebe7fe65127e47dba1d6132d277b8ea619cc4920931f990fb45f209b6a393b8de7
   languageName: node
   linkType: hard
 
-"@smithy/hash-stream-node@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/hash-stream-node@npm:4.2.0"
+"@smithy/hash-stream-node@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/hash-stream-node@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/1b277d53e371f65774124a8491834c96b57f1eff50970d91568b6fb5fea696653c9573cbff69113747b86dfa1f3d811c5cada97f8621306af3753061995d6072
+  checksum: 10c0/a342ca5dda588443137fc0d314cf6e82d84c0bf9b267e0a39309dda534bab79042a0b6f037d5cdfe894a31d354b06ddc8529d99a593aa339f010a088680794b9
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/invalid-dependency@npm:4.2.0"
+"@smithy/invalid-dependency@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/invalid-dependency@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/f20003683c9358a252d05711fe7e0ad1d400fcf6658acc50894e5f3d9d8fc9a8de079f958e418c4031a872dfde0de2ac59f829e630f90241d4d4bfaa830c32f6
+  checksum: 10c0/426cde94fc851007ede20cb7b201c03eb91a0d11ef5e0fb0308eb4d2fedbf2d82bc48367c765aa0491cf88fe731eb0c995ca6bcffe7381fd98b748795e2292a4
   languageName: node
   linkType: hard
 
@@ -2374,29 +2405,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/md5-js@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/md5-js@npm:4.2.0"
+"@smithy/md5-js@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/md5-js@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ad2adb13529496e20edabcdfe6ae5ab5e20ca11db2c100db94177b00834d738bead2b72e770d3729afc63e47479eef0d5cae41c5af1f0ee00e0717fca6ea7eaa
+  checksum: 10c0/6495f9592ef731468392f2b17bbf781f931555d8e853c70fa2ed41f9e612df133092dffa916f1b46fa06ea414db399f40c3845f19d975c368afeae76b010ce21
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/middleware-content-length@npm:4.2.0"
+"@smithy/middleware-content-length@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/middleware-content-length@npm:4.2.3"
   dependencies:
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c7e39e22c97dbcad8abe7ec9fb54381fce3acd601a2d8f3ea6f64e4f37663033e8ac5034e83814015d70277f587f7e0af8a60b3a01e46b06e305023e2d740bb8
+  checksum: 10c0/67aabc8c2257299e2985eba32cf0f728c23aeb1ba6f17bab1a99bfde1970a841d709592a855d6fa1ffb10c4c004a76e70d2804622529b010e9ee2e7b243630e6
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^4.3.1, @smithy/middleware-endpoint@npm:^4.3.3":
+"@smithy/middleware-endpoint@npm:^4.3.3":
   version: 4.3.3
   resolution: "@smithy/middleware-endpoint@npm:4.3.3"
   dependencies:
@@ -2412,31 +2443,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^4.4.1":
-  version: 4.4.3
-  resolution: "@smithy/middleware-retry@npm:4.4.3"
+"@smithy/middleware-endpoint@npm:^4.3.4":
+  version: 4.3.4
+  resolution: "@smithy/middleware-endpoint@npm:4.3.4"
   dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/service-error-classification": "npm:^4.2.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    "@smithy/util-retry": "npm:^4.2.2"
-    "@smithy/uuid": "npm:^1.1.0"
+    "@smithy/core": "npm:^3.17.0"
+    "@smithy/middleware-serde": "npm:^4.2.3"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/url-parser": "npm:^4.2.3"
+    "@smithy/util-middleware": "npm:^4.2.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9ab0f4cdf0e1b9a303ea8522af1b6e070640774d09218c7a9a3c7b82a962601cb0a6e690daf815021a8717a16c58c8a36950c6c4043dbef5ec3ffb0ebe36aa2a
+  checksum: 10c0/6a0e8a76fbdd88f6e1190bbf5282e57a4105aa2e771c9e4c2fe6d7765e2654ac9e0b334e3bdf1abacdd14f53879734266b8ed6aa05625a9a180bf157f0ee18d4
   languageName: node
   linkType: hard
 
-"@smithy/middleware-serde@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/middleware-serde@npm:4.2.0"
+"@smithy/middleware-retry@npm:^4.4.3":
+  version: 4.4.4
+  resolution: "@smithy/middleware-retry@npm:4.4.4"
   dependencies:
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/service-error-classification": "npm:^4.2.3"
+    "@smithy/smithy-client": "npm:^4.9.0"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    "@smithy/util-retry": "npm:^4.2.3"
+    "@smithy/uuid": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/f43d5b438aca7184c7bf43c3136ec90f14c8e3936a4624158cb27f160ae18fd8647a34c0e9f3d37e8c89e7c8711748dfe93ec388da8e0f227e01e0c5e669de30
+  checksum: 10c0/10a00cc54dd792160374daa709d2e3ed9146296de80e19ab0dce26db8de3170bba6c90fc3d2fbc542c8584f9ffa6cfc388c31910ccc245faa1071f8b8966651e
   languageName: node
   linkType: hard
 
@@ -2451,13 +2487,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-stack@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/middleware-stack@npm:4.2.0"
+"@smithy/middleware-serde@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/middleware-serde@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/37886fb6da8dfda4c09f2cca268214397de05009835095d773b463aa815670e9cdd8460c19bb7c6024dc0f1104baa0db3d0b9623ac30ceafd8b1a734054b53d7
+  checksum: 10c0/c8cda503c62e380167595efb1d44b5cc81e23e88c9941f3b7cc485c1948c9d0c379252acdf46419281abb844bc5080a31c54f7e00427c411d8ae929dad1050a1
   languageName: node
   linkType: hard
 
@@ -2471,15 +2508,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-config-provider@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@smithy/node-config-provider@npm:4.3.0"
+"@smithy/middleware-stack@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/middleware-stack@npm:4.2.3"
   dependencies:
-    "@smithy/property-provider": "npm:^4.2.0"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e67e3b4d281947cd7bfe358a4a40349f52c4761ec4903c4392e27ee6816eb3b0ba3d1e9d1c196ff2f28ee3ae4701945d0dfd234203aa93bc30b46146070b7216
+  checksum: 10c0/4a2cc539a6850501831a502a35eb135d5801003c3061e71e6cfc2cceba94a4db1a81e0c7f06f867871d20fc9b24868bddec513f3759ca484b299b153adf32dae
   languageName: node
   linkType: hard
 
@@ -2495,20 +2530,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@smithy/node-http-handler@npm:4.3.0"
+"@smithy/node-config-provider@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "@smithy/node-config-provider@npm:4.3.3"
   dependencies:
-    "@smithy/abort-controller": "npm:^4.2.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/querystring-builder": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/30752ee8bd3d426847221417db3742e8e976615de8277e345af58899845e0e35438e4921056849f9d505a20af0f7512cb39276b68d0da5446d0b275f038bdeaf
+  checksum: 10c0/f8a6839f5850c289be5cc366fe45c9a0553752c5851f3b2eeb2e0b8cdeda183535767d41f7e9e99bfe3bfe7f6fd50c5861a6acd802e0ec49a12caa4789dde1b8
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^4.4.1, @smithy/node-http-handler@npm:~4.4.1":
+"@smithy/node-http-handler@npm:^4.4.1":
   version: 4.4.1
   resolution: "@smithy/node-http-handler@npm:4.4.1"
   dependencies:
@@ -2521,13 +2555,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/property-provider@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/property-provider@npm:4.2.0"
+"@smithy/node-http-handler@npm:^4.4.2, @smithy/node-http-handler@npm:~4.4.2":
+  version: 4.4.2
+  resolution: "@smithy/node-http-handler@npm:4.4.2"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/abort-controller": "npm:^4.2.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/querystring-builder": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8ea9ccc9d3e67895c7002a3f5ab2f3f8b3432213eff3e5b3e4d81845273903de706e6c46e815b39e00c2fc5bf76a341d99e396cb9dc0c9cdc5981a35c83991a1
+  checksum: 10c0/60f3d95b03885440ae3acc31f5bacea8fbdd072b8f9b96080887bd24e1c9e697cbc785d8cb5d3eb1eb26746a8c12d2df93924bad255e4adee10fad7476e29202
   languageName: node
   linkType: hard
 
@@ -2541,13 +2578,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "@smithy/protocol-http@npm:5.3.0"
+"@smithy/property-provider@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/property-provider@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/718f1729c6b44a0d493ed4d815e9b6037fd50a87d9f7ac6070d53c083f11d1e460c6edc5997b2d8c8138559d15e2a79c1bd26534357c55c32bc5d2aaae625d3a
+  checksum: 10c0/1dc7a673023f3f4bb9e6fb879c5e02972d5e8dbc9d3aab36f6a1ef2ee897223416c4f98a2455e7837e42dcd923cbe18dcffd60843c6f8eef632fdfa4ebd529b8
   languageName: node
   linkType: hard
 
@@ -2561,14 +2598,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/querystring-builder@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/querystring-builder@npm:4.2.0"
+"@smithy/protocol-http@npm:^5.3.3":
+  version: 5.3.3
+  resolution: "@smithy/protocol-http@npm:5.3.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/util-uri-escape": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/01eb2e947130c1d88e67da65032e88911f6d2f4fa99f56555370fa765e63c629273e06537d5c5160f882b64abbf524168a8b510dc5de6ac2e161a53e914d7ef7
+  checksum: 10c0/f94d43aefcabc89b3de881b6d11b40ca46367a938be7cb7ebea85a289d373f18b68453c7374e9d254805b84c336b8654fd2c6bbbf34b3974752de2b0774c7023
   languageName: node
   linkType: hard
 
@@ -2583,13 +2619,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/querystring-parser@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/querystring-parser@npm:4.2.0"
+"@smithy/querystring-builder@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/querystring-builder@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-uri-escape": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9d50446af317bd5231514151a8a00d808db985543a2c5aa755b5b3bf1c7ce0290a652dbebb577709d2a7fa51279ad162e5551e780e5b8360eeda4cd88beaa828
+  checksum: 10c0/a29741ddde6f9e9e4e3774b4008a12ecc189a9296b6ac6df4a563bd7e3e18352674e754bfbf2a87b2c0e9cede77e51bee88c54fb169d99b30f3f803571cb985e
   languageName: node
   linkType: hard
 
@@ -2603,12 +2640,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/service-error-classification@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/service-error-classification@npm:4.2.0"
+"@smithy/querystring-parser@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/querystring-parser@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
-  checksum: 10c0/943cf1afc5d0337fb35625ec1ffc1128062d12d6d97b33f7d14dad760b2b02bcb982111c131a5ada74ebe3d03fa3d12506caaa66c549fad5731718c1f4133ddd
+    "@smithy/types": "npm:^4.8.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/974c20463b18dfc90b9446713ab959c1998ffd2269e512942fd16d831f44ef2684db700ba82afe9510c8a59b06e0765cc70a1eacc1ce4d7902a20c3e441e715e
   languageName: node
   linkType: hard
 
@@ -2621,13 +2659,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/shared-ini-file-loader@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@smithy/shared-ini-file-loader@npm:4.3.0"
+"@smithy/service-error-classification@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/service-error-classification@npm:4.2.3"
   dependencies:
-    "@smithy/types": "npm:^4.6.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/73d39e470acea3b635532065987f4aab72b3af73840d3d92154429f4273f0d2d3269e852da2420dd6a7d2a2fc69c38cfd6a9802a4b67002b830e9babe53fde0d
+    "@smithy/types": "npm:^4.8.0"
+  checksum: 10c0/8cd7327515125632a5b7535a9db24ab3f3d733253224d260ac6bf94e04ed3abf99ebd6cfb723d160b3fe49aa87c573dc51775656f4a661939851521e1fd750bb
   languageName: node
   linkType: hard
 
@@ -2641,23 +2678,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/signature-v4@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "@smithy/signature-v4@npm:5.3.0"
+"@smithy/shared-ini-file-loader@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "@smithy/shared-ini-file-loader@npm:4.3.3"
   dependencies:
-    "@smithy/is-array-buffer": "npm:^4.2.0"
-    "@smithy/protocol-http": "npm:^5.3.0"
-    "@smithy/types": "npm:^4.6.0"
-    "@smithy/util-hex-encoding": "npm:^4.2.0"
-    "@smithy/util-middleware": "npm:^4.2.0"
-    "@smithy/util-uri-escape": "npm:^4.2.0"
-    "@smithy/util-utf8": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e581445d947322146358dbc4adc42cecda31892d14bc1750fac205a1bd25feb210d80aafa03428108018f67998a9b3df888f423820af55bac05d2466e75610da
+  checksum: 10c0/8e5092d0be0a45b265d0a469dfded89aa3da93e751262efa71e358ca95902a3e34f6ae1465790c7fea131e6a945f322a357b5d681c1a5f66baf4acbfff347937
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^4.7.1, @smithy/smithy-client@npm:^4.8.1":
+"@smithy/signature-v4@npm:^5.3.2":
+  version: 5.3.3
+  resolution: "@smithy/signature-v4@npm:5.3.3"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^4.2.0"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-hex-encoding": "npm:^4.2.0"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    "@smithy/util-uri-escape": "npm:^4.2.0"
+    "@smithy/util-utf8": "npm:^4.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/454c5bc2847b066741fed57c7ea4ace1d6c3cb92387c78f3fd1ebf4c4a8629a65322bd13dd6f3dc62ef1f6b2f8d6d4ed88dfe8ce892c2fc6945d78e34e18727c
+  languageName: node
+  linkType: hard
+
+"@smithy/smithy-client@npm:^4.8.1":
   version: 4.8.1
   resolution: "@smithy/smithy-client@npm:4.8.1"
   dependencies:
@@ -2672,21 +2719,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/smithy-client@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "@smithy/smithy-client@npm:4.9.0"
+  dependencies:
+    "@smithy/core": "npm:^3.17.0"
+    "@smithy/middleware-endpoint": "npm:^4.3.4"
+    "@smithy/middleware-stack": "npm:^4.2.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-stream": "npm:^4.5.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3a4c045b6d81e2d7803aa1cbac6579481c2a6b204d42f92cd832c6b076bb7673afcd3e9c37050049c594992ca3591aa257c54c2a7d06f729d1d7ebe1942f1a6c
+  languageName: node
+  linkType: hard
+
 "@smithy/types@npm:^3.7.1":
   version: 3.7.1
   resolution: "@smithy/types@npm:3.7.1"
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/c82ad86087b6e0d2261f581a8cca1694a0af31458d7789ff5d8787973b4940a6d035082005dfc87857f266ee9cb512f7eb80535917e6dd6eb3d7d70c45d0f9aa
-  languageName: node
-  linkType: hard
-
-"@smithy/types@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "@smithy/types@npm:4.6.0"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/7a791fa2ad4a4407875076088b6438a6d328af9675705e64fba046c1ca84dbbdd0b9e398f4c45f5c6bc20a8b312aec0e5e69dd9114c5f7bd0a01ef23a646c6cd
   languageName: node
   linkType: hard
 
@@ -2699,14 +2752,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/url-parser@npm:4.2.0"
+"@smithy/types@npm:^4.8.0":
+  version: 4.8.0
+  resolution: "@smithy/types@npm:4.8.0"
   dependencies:
-    "@smithy/querystring-parser": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/3e76168d2eb972e07a70cf9a4e1a45faf1915474bce399e3c1836dec9794b744e804f4c5bc0b0fd1f5f6582fbb08c716072225b5bbe7aab59d9b3a026b1a7a18
+  checksum: 10c0/342173aeaa80b3837dce51c393a3fcab7db9b3ec1481cbc6d00298566076481b88e274c258c2dab54112641d66ab678c7ed7dc2c2a4500ffcf407a6d61c33fd0
   languageName: node
   linkType: hard
 
@@ -2718,6 +2769,17 @@ __metadata:
     "@smithy/types": "npm:^4.7.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/da5bfb3ad9670437cd917c9be7a9f7563a7d59a67d0dd639b306e439cdf1fed651e4d1f8e3ee9f66fafb938668419284e2c3d29fee29b3e8b708c826ddecac2d
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/url-parser@npm:4.2.3"
+  dependencies:
+    "@smithy/querystring-parser": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/fe624e0ed2447a6e27c32560aaf8371847982185743cfefe4d5fd46ddeb05bff12cd9fcdb4e568d1ce0c7dc1e5317e0e3cc5e78096c3ceb0fb77da93f86e7f56
   languageName: node
   linkType: hard
 
@@ -2779,41 +2841,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^4.3.0":
-  version: 4.3.2
-  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.2"
+"@smithy/util-defaults-mode-browser@npm:^4.3.2":
+  version: 4.3.3
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.3"
   dependencies:
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/smithy-client": "npm:^4.9.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/143041912a4819909c317e7c7a23270e49bdfdc19b36e3e296247ca2ce1e47db1e46523910b21bb5e8b07fb5b57daf653e5226dad0670f7328d44914592147ef
+  checksum: 10c0/e18e571affd7b580454efbadb28061dfe491bf76faf40a0ace12daf27f439b327b24c621c94e85528c4e6fcd0506087905d3957fb27a88b6f203a16ca7155cd3
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^4.2.1":
-  version: 4.2.3
-  resolution: "@smithy/util-defaults-mode-node@npm:4.2.3"
+"@smithy/util-defaults-mode-node@npm:^4.2.3":
+  version: 4.2.4
+  resolution: "@smithy/util-defaults-mode-node@npm:4.2.4"
   dependencies:
-    "@smithy/config-resolver": "npm:^4.3.2"
-    "@smithy/credential-provider-imds": "npm:^4.2.2"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
+    "@smithy/config-resolver": "npm:^4.3.3"
+    "@smithy/credential-provider-imds": "npm:^4.2.3"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/smithy-client": "npm:^4.9.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e572c8ce3b73bd8dd12e0987bbe0a4c97e2f42d03d58f61ad2ba9dbd261e491b8367d08f7322b1679407df53c6a4d0988cb1a8766271ff9914cb5232dc25670c
+  checksum: 10c0/b6507506a6601441ca4a6b31c5041587834f891b5388d6163f2b550da81b6a12838664d897f6a834edad037475db3d4959e9a869d404c844df1b266ca7a17c3e
   languageName: node
   linkType: hard
 
-"@smithy/util-endpoints@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@smithy/util-endpoints@npm:3.2.0"
+"@smithy/util-endpoints@npm:^3.2.2":
+  version: 3.2.3
+  resolution: "@smithy/util-endpoints@npm:3.2.3"
   dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/0a05ea69df3ab29b451b0e90cee43b5fa038cf15d88f724f34accd1ff84d04e274c578e29b587bc40c25201cd9e4c89840d55319eef408b06618f30ac87f2cca
+  checksum: 10c0/49daffb28d384e7c58f04ac3610f295f41b3ceef78f295ebff6d737efa142e9c95e4eed6db06ca085de7497fc95a4dbb2be99050ca31d07f399aaf63ab0adf35
   languageName: node
   linkType: hard
 
@@ -2823,16 +2885,6 @@ __metadata:
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/aaa94a69f03d14d3f28125cc915ca421065735e2d05d7305f0958a50021b2fce4fc68a248328e6b5b612dbaa49e471d481ff513bf89554f659f0a49573e97312
-  languageName: node
-  linkType: hard
-
-"@smithy/util-middleware@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/util-middleware@npm:4.2.0"
-  dependencies:
-    "@smithy/types": "npm:^4.6.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/db64843017fed2fcda503af98b47f5c5d8e36d537ea24e5d12063a1865aa52f6ffb2ae0757c89f5734bcae2f5b3fa5e6a592eac9e8fb35f87dd84e644fd8396b
   languageName: node
   linkType: hard
 
@@ -2846,14 +2898,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/util-retry@npm:4.2.0"
+"@smithy/util-middleware@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/util-middleware@npm:4.2.3"
   dependencies:
-    "@smithy/service-error-classification": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d972acbd9e9dd524dba50cdb34eb7cc92ff305dbb8b2c4b7a270546bc75329f67c041312306f2e1bec3fb486ce3334c3e4812c03fe9950ff21d11f3336d1ce29
+  checksum: 10c0/e98d461754d849b543a69e6a0fa74448cf00cf0954d6f484f735bcbf6c10a51cf63ad2090bcd8f276c19cbe7c413075ee49e6018cad8c15c3844480fa0efd0a1
   languageName: node
   linkType: hard
 
@@ -2868,7 +2919,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^4.5.0, @smithy/util-stream@npm:^4.5.2":
+"@smithy/util-retry@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/util-retry@npm:4.2.3"
+  dependencies:
+    "@smithy/service-error-classification": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9340714056d3ae6513c2527ba0806712aa4e86532ead5150dd0d34210a9f6d10ea1bb55cf4efa3711234444b58dca561a2708d885e61b2dd926a7cb6cf74baa2
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.5.2":
   version: 4.5.2
   resolution: "@smithy/util-stream@npm:4.5.2"
   dependencies:
@@ -2881,6 +2943,22 @@ __metadata:
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/aade6b07adfb6cc9e85fbdd3ce70959e95550d849d7f89d87c61148d1189258ee9f2a589c4c7cbd264776db945bef5b6dee76277439c0a9e4ecf9651b07fe383
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.5.3":
+  version: 4.5.3
+  resolution: "@smithy/util-stream@npm:4.5.3"
+  dependencies:
+    "@smithy/fetch-http-handler": "npm:^5.3.4"
+    "@smithy/node-http-handler": "npm:^4.4.2"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-base64": "npm:^4.3.0"
+    "@smithy/util-buffer-from": "npm:^4.2.0"
+    "@smithy/util-hex-encoding": "npm:^4.2.0"
+    "@smithy/util-utf8": "npm:^4.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/268c2810308bdde83eb833e179d3c5ffd935ffe5021cb857ce4291c68347fb0ba5409fb806bbff3e455af91d302611970a0d43180795d0c78356ac629a155c8a
   languageName: node
   linkType: hard
 
@@ -2913,14 +2991,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/util-waiter@npm:4.2.0"
+"@smithy/util-waiter@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/util-waiter@npm:4.2.3"
   dependencies:
-    "@smithy/abort-controller": "npm:^4.2.0"
-    "@smithy/types": "npm:^4.6.0"
+    "@smithy/abort-controller": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/fc72b46d83f66172328be84a48df969890ac2f88b449a4937ac1510edfce1f6792f03b28afd337735da6d9469461e35f8d56d69f1aa6f2b3eaf663e791829f42
+  checksum: 10c0/dcb37f2e3987f4ffda091e0048a8bc04fa68d67ca12d3306c5da8d88678f89247591e5f4da505f11a598137c575c6860cd39648e4c3d55991977a8b13fa0a35a
   languageName: node
   linkType: hard
 
@@ -3001,8 +3079,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/file-asset-apis@workspace:packages/file-asset-apis"
   dependencies:
-    "@aws-sdk/client-s3": "npm:~3.908.0"
-    "@smithy/node-http-handler": "npm:~4.4.1"
+    "@aws-sdk/client-s3": "npm:~3.911.0"
+    "@smithy/node-http-handler": "npm:~4.4.2"
     "@terascope/scripts": "npm:~1.21.8"
     "@terascope/utils": "npm:~1.10.4"
     "@types/jest": "npm:~30.0.0"
@@ -3580,12 +3658,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~24.7.2":
-  version: 24.7.2
-  resolution: "@types/node@npm:24.7.2"
+"@types/node@npm:~24.8.0":
+  version: 24.8.0
+  resolution: "@types/node@npm:24.8.0"
   dependencies:
     undici-types: "npm:~7.14.0"
-  checksum: 10c0/03f662f10e4b89bc97016e067101cbabe55025b54c24afb581fb50992d5eeaaf417bdae34bbc668ae8759d3cdbbbadf35fc8b9b29d26f52ede2525d48e919e49
+  checksum: 10c0/6ba1a268dec49b46c3301193394bfe6203a8d44453e32d6666e5daa35d2b5251425e7ac81444edae4c7f5bd12feed3324eba338c52b5630b258ff0e5040cd646
   languageName: node
   linkType: hard
 
@@ -6307,7 +6385,7 @@ __metadata:
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
     "@types/json2csv": "npm:~5.0.7"
-    "@types/node": "npm:~24.7.2"
+    "@types/node": "npm:~24.8.0"
     "@types/node-gzip": "npm:~1.1.3"
     "@types/semver": "npm:~7.7.1"
     eslint: "npm:~9.37.0"


### PR DESCRIPTION
This PR updates the following dependencies:

## Workspace

- @terascope/scripts: `v1.21.8`
- @types/node: `v24.8.0`
- semver: `v7.7.3`
- ts-jest: `v29.4.5`

## @terascope/file-asset-apis

- @aws-sdk/client-s3: `v3.911.0`
- @smithy/node-http-handler: `v4.4.2`
- ts-jest: `v29.4.5`
- @terascope/scripts: `v1.21.8`