### PR TITLE
bundled deps update 2025-10-27

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@terascope/file-asset-apis": "~1.1.2",
         "@terascope/job-components": "~1.12.4",
-        "csvtojson": "~2.0.10",
+        "csvtojson": "~2.0.13",
         "fs-extra": "~11.3.2",
         "json2csv": "5.0.7",
         "lz4-asm": "~0.4.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
         "@types/json2csv": "~5.0.7",
-        "@types/node": "~24.8.1",
+        "@types/node": "~24.9.1",
         "@types/node-gzip": "~1.1.3",
         "@types/semver": "~7.7.1",
         "eslint": "~9.38.0",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -21,10 +21,10 @@
         "test:watch": "ts-scripts test --watch . --"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "~3.913.0",
-        "@smithy/node-http-handler": "~4.4.2",
+        "@aws-sdk/client-s3": "~3.917.0",
+        "@smithy/node-http-handler": "~4.4.3",
         "@terascope/utils": "~1.10.4",
-        "csvtojson": "~2.0.10",
+        "csvtojson": "~2.0.13",
         "fs-extra": "~11.3.2",
         "json2csv": "5.0.7",
         "lz4-asm": "~0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,494 +97,492 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:~3.913.0":
-  version: 3.913.0
-  resolution: "@aws-sdk/client-s3@npm:3.913.0"
+"@aws-sdk/client-s3@npm:~3.917.0":
+  version: 3.917.0
+  resolution: "@aws-sdk/client-s3@npm:3.917.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:5.2.0"
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/credential-provider-node": "npm:3.913.0"
-    "@aws-sdk/middleware-bucket-endpoint": "npm:3.910.0"
-    "@aws-sdk/middleware-expect-continue": "npm:3.910.0"
-    "@aws-sdk/middleware-flexible-checksums": "npm:3.911.0"
-    "@aws-sdk/middleware-host-header": "npm:3.910.0"
-    "@aws-sdk/middleware-location-constraint": "npm:3.913.0"
-    "@aws-sdk/middleware-logger": "npm:3.910.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.910.0"
-    "@aws-sdk/middleware-sdk-s3": "npm:3.911.0"
-    "@aws-sdk/middleware-ssec": "npm:3.910.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.911.0"
-    "@aws-sdk/region-config-resolver": "npm:3.910.0"
-    "@aws-sdk/signature-v4-multi-region": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@aws-sdk/util-endpoints": "npm:3.910.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.910.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.911.0"
-    "@aws-sdk/xml-builder": "npm:3.911.0"
-    "@smithy/config-resolver": "npm:^4.3.2"
-    "@smithy/core": "npm:^3.16.1"
-    "@smithy/eventstream-serde-browser": "npm:^4.2.2"
-    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.2"
-    "@smithy/eventstream-serde-node": "npm:^4.2.2"
-    "@smithy/fetch-http-handler": "npm:^5.3.3"
-    "@smithy/hash-blob-browser": "npm:^4.2.3"
-    "@smithy/hash-node": "npm:^4.2.2"
-    "@smithy/hash-stream-node": "npm:^4.2.2"
-    "@smithy/invalid-dependency": "npm:^4.2.2"
-    "@smithy/md5-js": "npm:^4.2.2"
-    "@smithy/middleware-content-length": "npm:^4.2.2"
-    "@smithy/middleware-endpoint": "npm:^4.3.3"
-    "@smithy/middleware-retry": "npm:^4.4.3"
-    "@smithy/middleware-serde": "npm:^4.2.2"
-    "@smithy/middleware-stack": "npm:^4.2.2"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/node-http-handler": "npm:^4.4.1"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/url-parser": "npm:^4.2.2"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/credential-provider-node": "npm:3.917.0"
+    "@aws-sdk/middleware-bucket-endpoint": "npm:3.914.0"
+    "@aws-sdk/middleware-expect-continue": "npm:3.917.0"
+    "@aws-sdk/middleware-flexible-checksums": "npm:3.916.0"
+    "@aws-sdk/middleware-host-header": "npm:3.914.0"
+    "@aws-sdk/middleware-location-constraint": "npm:3.914.0"
+    "@aws-sdk/middleware-logger": "npm:3.914.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.914.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.916.0"
+    "@aws-sdk/middleware-ssec": "npm:3.914.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.916.0"
+    "@aws-sdk/region-config-resolver": "npm:3.914.0"
+    "@aws-sdk/signature-v4-multi-region": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@aws-sdk/util-endpoints": "npm:3.916.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.914.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.916.0"
+    "@aws-sdk/xml-builder": "npm:3.914.0"
+    "@smithy/config-resolver": "npm:^4.4.0"
+    "@smithy/core": "npm:^3.17.1"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.3"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.3"
+    "@smithy/eventstream-serde-node": "npm:^4.2.3"
+    "@smithy/fetch-http-handler": "npm:^5.3.4"
+    "@smithy/hash-blob-browser": "npm:^4.2.4"
+    "@smithy/hash-node": "npm:^4.2.3"
+    "@smithy/hash-stream-node": "npm:^4.2.3"
+    "@smithy/invalid-dependency": "npm:^4.2.3"
+    "@smithy/md5-js": "npm:^4.2.3"
+    "@smithy/middleware-content-length": "npm:^4.2.3"
+    "@smithy/middleware-endpoint": "npm:^4.3.5"
+    "@smithy/middleware-retry": "npm:^4.4.5"
+    "@smithy/middleware-serde": "npm:^4.2.3"
+    "@smithy/middleware-stack": "npm:^4.2.3"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/node-http-handler": "npm:^4.4.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/smithy-client": "npm:^4.9.1"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/url-parser": "npm:^4.2.3"
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-body-length-browser": "npm:^4.2.0"
     "@smithy/util-body-length-node": "npm:^4.2.1"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.2"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.3"
-    "@smithy/util-endpoints": "npm:^3.2.2"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    "@smithy/util-retry": "npm:^4.2.2"
-    "@smithy/util-stream": "npm:^4.5.2"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.4"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.6"
+    "@smithy/util-endpoints": "npm:^3.2.3"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    "@smithy/util-retry": "npm:^4.2.3"
+    "@smithy/util-stream": "npm:^4.5.4"
     "@smithy/util-utf8": "npm:^4.2.0"
-    "@smithy/util-waiter": "npm:^4.2.2"
+    "@smithy/util-waiter": "npm:^4.2.3"
     "@smithy/uuid": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/dd59c9ce81329ed48c9064fedc92758a4c1e12aae602f3d7395b7c92cd49ec4dda6cf784c67f6b9e4d692b007de2d34d2a45b924b4c7ba61604d93c283880929
+  checksum: 10c0/5ea7ade7433f5442c37530b6f5b45f5ff0536fb346d22cc5056424f0e145b09a747a9e01846fc6c83e002c64fd01318f83ac0d971e422540415a40983235a014
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/client-sso@npm:3.911.0"
+"@aws-sdk/client-sso@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/client-sso@npm:3.916.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/middleware-host-header": "npm:3.910.0"
-    "@aws-sdk/middleware-logger": "npm:3.910.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.910.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.911.0"
-    "@aws-sdk/region-config-resolver": "npm:3.910.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@aws-sdk/util-endpoints": "npm:3.910.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.910.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.911.0"
-    "@smithy/config-resolver": "npm:^4.3.2"
-    "@smithy/core": "npm:^3.16.1"
-    "@smithy/fetch-http-handler": "npm:^5.3.3"
-    "@smithy/hash-node": "npm:^4.2.2"
-    "@smithy/invalid-dependency": "npm:^4.2.2"
-    "@smithy/middleware-content-length": "npm:^4.2.2"
-    "@smithy/middleware-endpoint": "npm:^4.3.3"
-    "@smithy/middleware-retry": "npm:^4.4.3"
-    "@smithy/middleware-serde": "npm:^4.2.2"
-    "@smithy/middleware-stack": "npm:^4.2.2"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/node-http-handler": "npm:^4.4.1"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/url-parser": "npm:^4.2.2"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/middleware-host-header": "npm:3.914.0"
+    "@aws-sdk/middleware-logger": "npm:3.914.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.914.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.916.0"
+    "@aws-sdk/region-config-resolver": "npm:3.914.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@aws-sdk/util-endpoints": "npm:3.916.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.914.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.916.0"
+    "@smithy/config-resolver": "npm:^4.4.0"
+    "@smithy/core": "npm:^3.17.1"
+    "@smithy/fetch-http-handler": "npm:^5.3.4"
+    "@smithy/hash-node": "npm:^4.2.3"
+    "@smithy/invalid-dependency": "npm:^4.2.3"
+    "@smithy/middleware-content-length": "npm:^4.2.3"
+    "@smithy/middleware-endpoint": "npm:^4.3.5"
+    "@smithy/middleware-retry": "npm:^4.4.5"
+    "@smithy/middleware-serde": "npm:^4.2.3"
+    "@smithy/middleware-stack": "npm:^4.2.3"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/node-http-handler": "npm:^4.4.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/smithy-client": "npm:^4.9.1"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/url-parser": "npm:^4.2.3"
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-body-length-browser": "npm:^4.2.0"
     "@smithy/util-body-length-node": "npm:^4.2.1"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.2"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.3"
-    "@smithy/util-endpoints": "npm:^3.2.2"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    "@smithy/util-retry": "npm:^4.2.2"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.4"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.6"
+    "@smithy/util-endpoints": "npm:^3.2.3"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    "@smithy/util-retry": "npm:^4.2.3"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ef07589cf448bb30136e015d6ea594aa84704b45234fc984d0d9824a2d2f2f7595d14090766b92f46b116b39f41071b083f41d2e95a0eb4ebf8fbc39105903fd
+  checksum: 10c0/ce90c351bfeb207198136c378bd13fbceaec46b6306c62ea8b65d218391e5219afcfe6686313c7de13076f4e630dafb2c689639a0d76bd0773f09e09723fd2cc
   languageName: node
   linkType: hard
 
-"@aws-sdk/core@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/core@npm:3.911.0"
+"@aws-sdk/core@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/core@npm:3.916.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@aws-sdk/xml-builder": "npm:3.911.0"
-    "@smithy/core": "npm:^3.16.1"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/signature-v4": "npm:^5.3.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@aws-sdk/xml-builder": "npm:3.914.0"
+    "@smithy/core": "npm:^3.17.1"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/signature-v4": "npm:^5.3.3"
+    "@smithy/smithy-client": "npm:^4.9.1"
+    "@smithy/types": "npm:^4.8.0"
     "@smithy/util-base64": "npm:^4.3.0"
-    "@smithy/util-middleware": "npm:^4.2.2"
+    "@smithy/util-middleware": "npm:^4.2.3"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/438e7c7a5d75d970650c31d76d81a8d4152a779df0b2d757b7a4b110f31104989ce878f260b843ffa083f6dd3cef2e58304884373c9d750a4bad60e9a669a50f
+  checksum: 10c0/ee4d6b11e7b070376e2af698fabaeb8bce77dc3f752a4f2843e3fcce9fb9a3e2a41a9b24b6c19f26312cda83ef1f825756b7a07532d061e192307c1a2abcf93b
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.911.0"
+"@aws-sdk/credential-provider-env@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.916.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/09e9b080fdf63bb48575e9ef9e233ad5fcc895cd727fd3db2d45a012d188cb3612bc0e4b04fee1cf302f14c1a5fcc01b32e3e154263853bddec0a7f72a259707
+  checksum: 10c0/6a05a282c8599231b5e9af3cdd20abdc2ae0aff2fb2a126ca1fc171fed6cbe457e866d7791dca94d709b0b227a1fb59a63e35a806e6f3257a5d8ff32076b0e75
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-http@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/credential-provider-http@npm:3.911.0"
+"@aws-sdk/credential-provider-http@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.916.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/fetch-http-handler": "npm:^5.3.3"
-    "@smithy/node-http-handler": "npm:^4.4.1"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-stream": "npm:^4.5.2"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/fetch-http-handler": "npm:^5.3.4"
+    "@smithy/node-http-handler": "npm:^4.4.3"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/smithy-client": "npm:^4.9.1"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-stream": "npm:^4.5.4"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9bfe10fb49989e22db9b5fffcade6195e1fe9633d9eb8baf92b8e7e5a985f2a34df185ad42e05c66d8ace37851284c576ebc6e601e27cee5b8f833741567fa73
+  checksum: 10c0/482012b32e01118196af4f8018bfcc154f085b9a1ea1d419b2287a364d34674d58ead4d95d931c66160d698d1a1e414b3b6ddc0f8e6995a597f3f207699538ed
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.913.0":
-  version: 3.913.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.913.0"
+"@aws-sdk/credential-provider-ini@npm:3.917.0":
+  version: 3.917.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.917.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/credential-provider-env": "npm:3.911.0"
-    "@aws-sdk/credential-provider-http": "npm:3.911.0"
-    "@aws-sdk/credential-provider-process": "npm:3.911.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.911.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.911.0"
-    "@aws-sdk/nested-clients": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/credential-provider-imds": "npm:^4.2.2"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/credential-provider-env": "npm:3.916.0"
+    "@aws-sdk/credential-provider-http": "npm:3.916.0"
+    "@aws-sdk/credential-provider-process": "npm:3.916.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.916.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.917.0"
+    "@aws-sdk/nested-clients": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/credential-provider-imds": "npm:^4.2.3"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/567cf87a9b069b5d20fb829355802be30edff0c8e07e7660f13eb02341106b18a0ea8428eadc2f2ba2ab7374d2ea90a7eef3af89262fded4eecddb2024793ae8
+  checksum: 10c0/a89c4feeae5793073d186fbf28d9937c4a944cd5c167fdd09a14430734cb04c5dc8d79585ab8816b2963bfebce3b99bf73a33f5573e44c5ac27c9254bb644beb
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.913.0":
-  version: 3.913.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.913.0"
+"@aws-sdk/credential-provider-node@npm:3.917.0":
+  version: 3.917.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.917.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.911.0"
-    "@aws-sdk/credential-provider-http": "npm:3.911.0"
-    "@aws-sdk/credential-provider-ini": "npm:3.913.0"
-    "@aws-sdk/credential-provider-process": "npm:3.911.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.911.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/credential-provider-imds": "npm:^4.2.2"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/credential-provider-env": "npm:3.916.0"
+    "@aws-sdk/credential-provider-http": "npm:3.916.0"
+    "@aws-sdk/credential-provider-ini": "npm:3.917.0"
+    "@aws-sdk/credential-provider-process": "npm:3.916.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.916.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.917.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/credential-provider-imds": "npm:^4.2.3"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/096e5967f22143b8bb14c1d7e104c186b85d474424717caa909cbcd9c3aaa152c3bc6737ecb533ccf5707b8fba7b3f20ced668f23a454a46eaeb526cf59a8484
+  checksum: 10c0/4bea7242587e942f7c86818bb9705e145f6b63e3e4a55c15c4dfff383c0613a90dbae8027528fb473ff9c8b6c8f802f851405cb09bb49fb6eb76c91b74841cb1
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.911.0"
+"@aws-sdk/credential-provider-process@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.916.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/02563d2bd90b2a3b89d2ed338ea9dd2bb6a8f7585f7a77b4c3fc040f2d84e20b28196c2a61fc2b1298c0184a6a7ead22b7d5d87f8949c5d96057d638f06dd858
+  checksum: 10c0/a0cb35f6c79435613f7d4025fd7d8a898566d3c3c42cef76e9b01768d151193c0d235344134fa4514d65d76aa954633c9c424c95095e11b066bd8d01aea63126
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.911.0"
+"@aws-sdk/credential-provider-sso@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.916.0"
   dependencies:
-    "@aws-sdk/client-sso": "npm:3.911.0"
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/token-providers": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/client-sso": "npm:3.916.0"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/token-providers": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/9f590b512ae089ed072b637a341696a498dea0665d75440845f6b33e87b63d2719f2d06fe9a6ec8e40b02e18dbe054d2d4c5a444a8ea6c3ebd9d028825a8e881
+  checksum: 10c0/f9cd04514d0bc6495fb6cf8172e0cd202e19262b036ff06bbd4244a6c3573fa7d0b1f5d23aa5267a4b9606eeba8145831eccc7fd75d4a929e3fc893bf26776f0
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.911.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.917.0":
+  version: 3.917.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.917.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/nested-clients": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/nested-clients": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/bc7a5581d202dcc7d3d5d5d4295dc8408dd35eb7b630c38a3e73e4465500f5746901664207cf0e8313bc237fa319966f6ad29d1555617ad8f7832b6128cc8073
+  checksum: 10c0/34e6ee21ada45bca82c1b7425042ba5aa76675208102cb028f28ffc76de31935d86ba3bd5e7e6b58b8b67e3a41fc27c78dd9215fc1716a6f43858c8b4d1d98d7
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.910.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.914.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/types": "npm:3.914.0"
     "@aws-sdk/util-arn-parser": "npm:3.893.0"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
     "@smithy/util-config-provider": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/32154bd1870c691d5071e5275a17ba2ea542bece2bf2da8464389c95358f1631d199af3bba25958098f04bf9dc11a569fafb2bb96d452718170abab86597300b
+  checksum: 10c0/3bc67cf5a1cd8d9ba8bc9d63a515cf2cc47c391f0740145e21f3b7953f99bbf9b7261cea24bbeff580820d2653da98ce16dcb4819a15e24dc1ac2d8a9c658ba9
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.910.0"
+"@aws-sdk/middleware-expect-continue@npm:3.917.0":
+  version: 3.917.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.917.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/1e8b9426e8b1a7f0db82faded10ac8047310f52224468bb00c7271a172fe645518b46a92be3b7cfdf757179f5ee43d53f69c81be303c5f8851ae330028b5b20a
+  checksum: 10c0/5564391c330d43916e43feb86fd6df8b1bd5bcb30c50363edff62d8541d6b02e09b83e4421600d4eea29004208bec029fcc5b7c3f1002102e8d669321f13a702
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-flexible-checksums@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.911.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.916.0"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
     "@aws-crypto/crc32c": "npm:5.2.0"
     "@aws-crypto/util": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
     "@smithy/is-array-buffer": "npm:^4.2.0"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    "@smithy/util-stream": "npm:^4.5.2"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    "@smithy/util-stream": "npm:^4.5.4"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/706dcd0276be6a98d7d0bce671efb27c43921f909535fdf7c49934ba881e954ddfe763fdd428b1b22291ae1476a3db8442a70fef66e3fe3baf7caa23a962bd9b
+  checksum: 10c0/c62f083d16df44efcbb3240a5aa596e29ca11b3bacde091dc2122c9688f0190cedfbaddf57f9de27bd41617a2f6eee903c120e7cbceb2fc6c6856f4054bb0429
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.910.0"
+"@aws-sdk/middleware-host-header@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.914.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/bfd348a15b855a89a46a5c3cc18dbca94eda541847c3260b2d66b8c84440976cd527831bab7adaf3f6bc68fb9b61b885b69762dee3830cb960a2a18a8c517482
+  checksum: 10c0/f5141335b89132a7e54b799fb5e849a2162a79c9f3ff287e497938a6ddc9f81e2ebca7888759f83633cc4347c2510f937442695e24b9c5de07964e3545345cdd
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-location-constraint@npm:3.913.0":
-  version: 3.913.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.913.0"
+"@aws-sdk/middleware-location-constraint@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.914.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/3ff82856066eb482574404294baf38c6dcf4659a86fd08613839c24c347555dbab854c65eec671b539b2a263e86eedf254d97783712445c980e1928d7ca8bb61
+  checksum: 10c0/65204117f9dbfd5ff2719e1304b65ce234cbd114e11c75b7025bf0b21f99c402153e3e72cf359722499727f0c718f2aaa7a7e9a71193a97935780e8d09dd8dd5
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.910.0"
+"@aws-sdk/middleware-logger@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.914.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/33d0ec8c067701e8fb80f792ec4208decb0eb61502fd34377976bcd0aea5ee2c554a0861b3f42547a6a11abfe7ca5324c419d87dbe88def282b9ce4da2edb068
+  checksum: 10c0/d9011740d92d20b451a82e442069f81e57b5e86608573d753e4dedf80d9bfb5660fe2651aa542f26be7a16d97ec2aad708a80c1ae197ef0700ddfc6bc90e4554
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.910.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.914.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/types": "npm:3.914.0"
     "@aws/lambda-invoke-store": "npm:^0.0.1"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/bdf27349e500c8abffc67c5ed017dad8749b5a007d1e1da0fea7f12cb5e85a6255e28811e517566454a1a6a201fea6fe94cb8e90d4f8d8023cbcbf412afddcdd
+  checksum: 10c0/45f5dfb4352e2554642eed38cee2bb7265ecbff2144671656f87d8f52948f11a9c401e08e6e1e054cd84e9ade32e86648f8de5266a342cc2d1efd6709c7f1574
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.911.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.916.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
     "@aws-sdk/util-arn-parser": "npm:3.893.0"
-    "@smithy/core": "npm:^3.16.1"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/signature-v4": "npm:^5.3.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
+    "@smithy/core": "npm:^3.17.1"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/signature-v4": "npm:^5.3.3"
+    "@smithy/smithy-client": "npm:^4.9.1"
+    "@smithy/types": "npm:^4.8.0"
     "@smithy/util-config-provider": "npm:^4.2.0"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    "@smithy/util-stream": "npm:^4.5.2"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    "@smithy/util-stream": "npm:^4.5.4"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/5143427a345ff842c1fd83ea198f8456d928221b5b8f9a9b698cfda0dbc5cd4b3bf38cd9194faf98a89af9ebbd53199d0712944b8fefab905378bc8899d5206c
+  checksum: 10c0/6565e3c5fb5530f93c9b0104647a5ad779e9ce99d623f44ca62d0e8009d3e07846f6ca5b8427c50e82f2bb06da65dcf197d03697a6f78aaac338578b5132e2c9
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-ssec@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.910.0"
+"@aws-sdk/middleware-ssec@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.914.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/2156df7de3e63d426bc8fdc018298ae8dc6bcff55f9a21365de71142b0c61266f5e65657757a8815662f1b2a6d5c5a78e9b970bf4315907e6d7888059da0526a
+  checksum: 10c0/b7a0c24a43a3abae81e2fc423868ac7c290cc2253835953ccd6ff9dc64de31c534d85302c135267077f62b46476ea6b29173643043177fb75e7e605801635230
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.911.0"
+"@aws-sdk/middleware-user-agent@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.916.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@aws-sdk/util-endpoints": "npm:3.910.0"
-    "@smithy/core": "npm:^3.16.1"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@aws-sdk/util-endpoints": "npm:3.916.0"
+    "@smithy/core": "npm:^3.17.1"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4c8084ef88e5b62da3ac6dc0f28da12bea2b94a4962f95012253ee4c1ddb271e53448f7aa72c4a1fb5640f8a6621ec84713ce385943486c8e093b55c64ba6599
+  checksum: 10c0/4ad432b4fcc7c473c4b4dc2cf1fc7f2db8afbcb834471b746515f5f0c4b049276acd83a6dee59172166aa2df2288a821e0ee39d711dcd15fddc56ef62820d855
   languageName: node
   linkType: hard
 
-"@aws-sdk/nested-clients@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/nested-clients@npm:3.911.0"
+"@aws-sdk/nested-clients@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/nested-clients@npm:3.916.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/middleware-host-header": "npm:3.910.0"
-    "@aws-sdk/middleware-logger": "npm:3.910.0"
-    "@aws-sdk/middleware-recursion-detection": "npm:3.910.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.911.0"
-    "@aws-sdk/region-config-resolver": "npm:3.910.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@aws-sdk/util-endpoints": "npm:3.910.0"
-    "@aws-sdk/util-user-agent-browser": "npm:3.910.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.911.0"
-    "@smithy/config-resolver": "npm:^4.3.2"
-    "@smithy/core": "npm:^3.16.1"
-    "@smithy/fetch-http-handler": "npm:^5.3.3"
-    "@smithy/hash-node": "npm:^4.2.2"
-    "@smithy/invalid-dependency": "npm:^4.2.2"
-    "@smithy/middleware-content-length": "npm:^4.2.2"
-    "@smithy/middleware-endpoint": "npm:^4.3.3"
-    "@smithy/middleware-retry": "npm:^4.4.3"
-    "@smithy/middleware-serde": "npm:^4.2.2"
-    "@smithy/middleware-stack": "npm:^4.2.2"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/node-http-handler": "npm:^4.4.1"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/smithy-client": "npm:^4.8.1"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/url-parser": "npm:^4.2.2"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/middleware-host-header": "npm:3.914.0"
+    "@aws-sdk/middleware-logger": "npm:3.914.0"
+    "@aws-sdk/middleware-recursion-detection": "npm:3.914.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.916.0"
+    "@aws-sdk/region-config-resolver": "npm:3.914.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@aws-sdk/util-endpoints": "npm:3.916.0"
+    "@aws-sdk/util-user-agent-browser": "npm:3.914.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.916.0"
+    "@smithy/config-resolver": "npm:^4.4.0"
+    "@smithy/core": "npm:^3.17.1"
+    "@smithy/fetch-http-handler": "npm:^5.3.4"
+    "@smithy/hash-node": "npm:^4.2.3"
+    "@smithy/invalid-dependency": "npm:^4.2.3"
+    "@smithy/middleware-content-length": "npm:^4.2.3"
+    "@smithy/middleware-endpoint": "npm:^4.3.5"
+    "@smithy/middleware-retry": "npm:^4.4.5"
+    "@smithy/middleware-serde": "npm:^4.2.3"
+    "@smithy/middleware-stack": "npm:^4.2.3"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/node-http-handler": "npm:^4.4.3"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/smithy-client": "npm:^4.9.1"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/url-parser": "npm:^4.2.3"
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-body-length-browser": "npm:^4.2.0"
     "@smithy/util-body-length-node": "npm:^4.2.1"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.2"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.3"
-    "@smithy/util-endpoints": "npm:^3.2.2"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    "@smithy/util-retry": "npm:^4.2.2"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.4"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.6"
+    "@smithy/util-endpoints": "npm:^3.2.3"
+    "@smithy/util-middleware": "npm:^4.2.3"
+    "@smithy/util-retry": "npm:^4.2.3"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d1c993ad22f7e58d10d2fccade5f4e9d12b04f8304a6b06615c088f827105b75c75e14be4698d120038d6f7d6e7244204c15813a5c2d5f87d9ef6e347fc320ec
+  checksum: 10c0/fd77d4cb08f3176ee87f18f5771039f883d76013b3cfd0440c2592b8e953ef775d2058c2c485c1b8df27a6e6ae56de6560fbd824ac5a5fff98b6f20376857158
   languageName: node
   linkType: hard
 
-"@aws-sdk/region-config-resolver@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/region-config-resolver@npm:3.910.0"
+"@aws-sdk/region-config-resolver@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.914.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-config-provider": "npm:^4.2.0"
-    "@smithy/util-middleware": "npm:^4.2.2"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/config-resolver": "npm:^4.4.0"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/03bc2172d0c3b134cbb496e8546606a8821fc4f0272ea03aadfd653b29956ddbbfa2ad3e12b7937d3e98d7b0f92e8fedb2af6559f2389c2d1d4ffc37bb55c5b0
+  checksum: 10c0/a473db628478a4403c34121231ed03c4b9c148659d797f8daa1ed7608b86bb23b1f85c63a99abb0efe9f540659d424d9e720b2e689cbcd7d61d888de610d4513
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.911.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.916.0"
   dependencies:
-    "@aws-sdk/middleware-sdk-s3": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/signature-v4": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/protocol-http": "npm:^5.3.3"
+    "@smithy/signature-v4": "npm:^5.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c9b619a8f8f49b7bf5e2d10518e3e9d66ceaaa6a991f18bfcc6dc23877984195d30f4d8adbc66c85b999a77dc66a4bbaa9c9b35c5e74e8f855c68b27bc526b49
+  checksum: 10c0/f0bb96a060b761a7a28c7e25d227c723c13a30f237588513894874a76c5ed6eac5ad5402901651ac7b187b3d7833f9b47681608e8e2ec030af07d3267ca27266
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/token-providers@npm:3.911.0"
+"@aws-sdk/token-providers@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/token-providers@npm:3.916.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.911.0"
-    "@aws-sdk/nested-clients": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/core": "npm:3.916.0"
+    "@aws-sdk/nested-clients": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/property-provider": "npm:^4.2.3"
+    "@smithy/shared-ini-file-loader": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/287a1777c8885a6e0a2af0856356e3fc063c1d8d28abda3602b862d0aa4a56593751d4e2b820cb0588432b890d68f432b00720cdf4e04fc04a6c79cc9f9c3439
+  checksum: 10c0/97d7ed9895f59eeadf597ec335d951a552a017e34d1e4283f42b8dc965ce115449d03219ac5364401fe2f82ad2bc32a96139d91be71faf17921886af9653b6a9
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/types@npm:3.910.0"
+"@aws-sdk/types@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/types@npm:3.914.0"
   dependencies:
-    "@smithy/types": "npm:^4.7.1"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/b91c035d68999dfef31ffb81f0f6dea6d9a763339293d4267975dc9bc0f946d39d48fa51dbe643360d8643686e6ccce783f2ae1e3dfabd4d470bb8834c1186d3
+  checksum: 10c0/71de24f076587ffc53acdc62ef16de711bd0c00f9a40491cd12a2c762e794c751e4ab79e0fb798c06a6a0e731cf0716f7833add085b1c85b7bfa2fba75e83937
   languageName: node
   linkType: hard
 
@@ -607,16 +605,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-endpoints@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.910.0"
+"@aws-sdk/util-endpoints@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.916.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/url-parser": "npm:^4.2.2"
-    "@smithy/util-endpoints": "npm:^3.2.2"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/types": "npm:^4.8.0"
+    "@smithy/url-parser": "npm:^4.2.3"
+    "@smithy/util-endpoints": "npm:^3.2.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/1944c8ff7fd50ef6e018a27c378ae0eba7672900827cbc2b1604d04ce08ec2a74dea11eb3a9ba63a00e4083206be93e9a90aaa424f841e5f5c55888cf0e07073
+  checksum: 10c0/ea67106b19f10a8cd01bda8dc76978c844723056b2fa8fad637c4a456b2d4a1e131e7f872539f580e25fc41bdce219427b209eceb0fceb3bd610cab82b8025fb
   languageName: node
   linkType: hard
 
@@ -629,44 +627,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.910.0":
-  version: 3.910.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.910.0"
+"@aws-sdk/util-user-agent-browser@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.914.0"
   dependencies:
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/types": "npm:^4.8.0"
     bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/7f331a95df724548198a076f560cb1a7491c4b87dc76b2eea623ef6acc2c4b186e50a393336a26ecf83fadb9375c9eb668e5b5bc154adcf3e17ecf7ae0f89cc0
+  checksum: 10c0/d9adf87efbd9ecb242cf92b489f1f490008eb0149c182a72452f3352dd4b6bf0a4bf974f18369d780ed5f2341bb0c526e81611da36e5f5bf0613aca1eea3bdab
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.911.0"
+"@aws-sdk/util-user-agent-node@npm:3.916.0":
+  version: 3.916.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.916.0"
   dependencies:
-    "@aws-sdk/middleware-user-agent": "npm:3.911.0"
-    "@aws-sdk/types": "npm:3.910.0"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
+    "@aws-sdk/middleware-user-agent": "npm:3.916.0"
+    "@aws-sdk/types": "npm:3.914.0"
+    "@smithy/node-config-provider": "npm:^4.3.3"
+    "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 10c0/e7ceaa43633aa27f7d3239fc1006d844a23ab720635c2898f0da5024588feb77a1c77cd3142d1450d751b93ee4ae404756c7364230b2ac7b4ef473372ada1378
+  checksum: 10c0/60910c61254d342fd08c22bc781494bb34c2a3e153e6fe787f7e18177677cf8023665bf09ef77669864a69c07cc3fe1fd412bb82e0cc8e665dbbf2b317540860
   languageName: node
   linkType: hard
 
-"@aws-sdk/xml-builder@npm:3.911.0":
-  version: 3.911.0
-  resolution: "@aws-sdk/xml-builder@npm:3.911.0"
+"@aws-sdk/xml-builder@npm:3.914.0":
+  version: 3.914.0
+  resolution: "@aws-sdk/xml-builder@npm:3.914.0"
   dependencies:
-    "@smithy/types": "npm:^4.7.1"
+    "@smithy/types": "npm:^4.8.0"
     fast-xml-parser: "npm:5.2.5"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/174aa60f5be883954b33082af65a20238a64bd69c4983ee7617786b77624325ddd8ae844b7a59e5d3bb92d33519e5bb9a6d626ce2fa547bd60455ba65867ddda
+  checksum: 10c0/d229350c17594a04165ed812e79f01f7ddc1ae3c562a95684e70e897c5feb5ae9b58a54443808ed5f883544d7a8ab720d8a6395dfdb84a6a43587171772ee184
   languageName: node
   linkType: hard
 
@@ -2152,16 +2150,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/abort-controller@npm:4.2.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/eb0428d3f1cde2f7689b84f725db23d1160c493addabd00a48f1589df6dad9cf69c88050017bdaf57dc37f81ce8b390673aebdf358195598b63a8481f89056c5
-  languageName: node
-  linkType: hard
-
 "@smithy/abort-controller@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/abort-controller@npm:4.2.3"
@@ -2191,53 +2179,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "@smithy/config-resolver@npm:4.3.2"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-config-provider": "npm:^4.2.0"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/58ecefbab4b3fe802326e9a2c1d950714c44b701f6d1e36dd91d9e7f2f43d00f21c167ba1ee3a74b7f37305e7ed3a664204c16ce9691ded0603e5a8251329450
-  languageName: node
-  linkType: hard
-
-"@smithy/config-resolver@npm:^4.3.3":
-  version: 4.3.3
-  resolution: "@smithy/config-resolver@npm:4.3.3"
+"@smithy/config-resolver@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "@smithy/config-resolver@npm:4.4.0"
   dependencies:
     "@smithy/node-config-provider": "npm:^4.3.3"
     "@smithy/types": "npm:^4.8.0"
     "@smithy/util-config-provider": "npm:^4.2.0"
+    "@smithy/util-endpoints": "npm:^3.2.3"
     "@smithy/util-middleware": "npm:^4.2.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/297e16ebd901b6f22e22294806bc5e574e38cef0ff9ec2c03e5dd333883a108fc452a73d567f1dcad690d16337d7c726ba7e92c6b4e086712b6fd966f7e3c0b7
+  checksum: 10c0/f33e1c4569980e614dea8b709dbd8e120b725caf4a7cc557d9d31a91df1755ccc1a2179cf26681eebf713e755ad38d6b58f7aca00dfe2c3390e9481221530e43
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^3.16.1":
-  version: 3.16.1
-  resolution: "@smithy/core@npm:3.16.1"
-  dependencies:
-    "@smithy/middleware-serde": "npm:^4.2.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-base64": "npm:^4.3.0"
-    "@smithy/util-body-length-browser": "npm:^4.2.0"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    "@smithy/util-stream": "npm:^4.5.2"
-    "@smithy/util-utf8": "npm:^4.2.0"
-    "@smithy/uuid": "npm:^1.1.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/34892aaa74b1559c821d70d058d150fc7d7a4b09c8164c9e40ff493dddf657cd4a28e5db7dffd5b2ff76df644bb48e6b66d4213f483390fdda3f6711893517ef
-  languageName: node
-  linkType: hard
-
-"@smithy/core@npm:^3.17.0":
-  version: 3.17.0
-  resolution: "@smithy/core@npm:3.17.0"
+"@smithy/core@npm:^3.17.1":
+  version: 3.17.1
+  resolution: "@smithy/core@npm:3.17.1"
   dependencies:
     "@smithy/middleware-serde": "npm:^4.2.3"
     "@smithy/protocol-http": "npm:^5.3.3"
@@ -2245,24 +2203,11 @@ __metadata:
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-body-length-browser": "npm:^4.2.0"
     "@smithy/util-middleware": "npm:^4.2.3"
-    "@smithy/util-stream": "npm:^4.5.3"
+    "@smithy/util-stream": "npm:^4.5.4"
     "@smithy/util-utf8": "npm:^4.2.0"
     "@smithy/uuid": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/3e7b0dfeac4b591b8caf3dd4ae68271b807044d2b8f22c5d97c6a10d1c27a15d329a5130d19cf416b60f4cdcbe46fad5491e419049e030629231002feef75846
-  languageName: node
-  linkType: hard
-
-"@smithy/credential-provider-imds@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/credential-provider-imds@npm:4.2.2"
-  dependencies:
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/url-parser": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/53e1543b195d606250fa6c4f68b81c98f9e11b4cc473f165f82bbf266ad4850d7549b05fa0424ccdf5a5b2c32bfdc809e39e124fab6e4a87f0d6a5233436647a
+  checksum: 10c0/2b3e9f9c06b73e4e12361bec6bcf59ae6a33f60252a85114be91656765aaa9ff77fa7a9e0129875aba81b21c6630455720b8b174e1145be72aec86245c2dbf4b
   languageName: node
   linkType: hard
 
@@ -2291,7 +2236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^4.2.2":
+"@smithy/eventstream-serde-browser@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/eventstream-serde-browser@npm:4.2.3"
   dependencies:
@@ -2302,7 +2247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^4.3.2":
+"@smithy/eventstream-serde-config-resolver@npm:^4.3.3":
   version: 4.3.3
   resolution: "@smithy/eventstream-serde-config-resolver@npm:4.3.3"
   dependencies:
@@ -2312,7 +2257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-node@npm:^4.2.2":
+"@smithy/eventstream-serde-node@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/eventstream-serde-node@npm:4.2.3"
   dependencies:
@@ -2334,19 +2279,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^5.3.3":
-  version: 5.3.3
-  resolution: "@smithy/fetch-http-handler@npm:5.3.3"
-  dependencies:
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/querystring-builder": "npm:^4.2.2"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-base64": "npm:^4.3.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/1f1635f3c4922f5e22e9d1a26248146e269bf847880ae57c94fe3425def0abd2938aa43678f141014bb923c03be117f9beee79e633a0dd1c4ab5eeb8e38350d9
-  languageName: node
-  linkType: hard
-
 "@smithy/fetch-http-handler@npm:^5.3.4":
   version: 5.3.4
   resolution: "@smithy/fetch-http-handler@npm:5.3.4"
@@ -2360,7 +2292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/hash-blob-browser@npm:^4.2.3":
+"@smithy/hash-blob-browser@npm:^4.2.4":
   version: 4.2.4
   resolution: "@smithy/hash-blob-browser@npm:4.2.4"
   dependencies:
@@ -2372,7 +2304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^4.2.2":
+"@smithy/hash-node@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/hash-node@npm:4.2.3"
   dependencies:
@@ -2384,7 +2316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/hash-stream-node@npm:^4.2.2":
+"@smithy/hash-stream-node@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/hash-stream-node@npm:4.2.3"
   dependencies:
@@ -2395,7 +2327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^4.2.2":
+"@smithy/invalid-dependency@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/invalid-dependency@npm:4.2.3"
   dependencies:
@@ -2423,7 +2355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/md5-js@npm:^4.2.2":
+"@smithy/md5-js@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/md5-js@npm:4.2.3"
   dependencies:
@@ -2434,7 +2366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^4.2.2":
+"@smithy/middleware-content-length@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/middleware-content-length@npm:4.2.3"
   dependencies:
@@ -2445,27 +2377,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^4.3.3":
-  version: 4.3.3
-  resolution: "@smithy/middleware-endpoint@npm:4.3.3"
+"@smithy/middleware-endpoint@npm:^4.3.5":
+  version: 4.3.5
+  resolution: "@smithy/middleware-endpoint@npm:4.3.5"
   dependencies:
-    "@smithy/core": "npm:^3.16.1"
-    "@smithy/middleware-serde": "npm:^4.2.2"
-    "@smithy/node-config-provider": "npm:^4.3.2"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/url-parser": "npm:^4.2.2"
-    "@smithy/util-middleware": "npm:^4.2.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/ea1adb2887178ac6421a9b59e069a1e043960f8f5422bd54183c8275b6fa8c479ac752e3d726f2d711714e9bc15664bf718495bddafaac5713a50b708216977a
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-endpoint@npm:^4.3.4":
-  version: 4.3.4
-  resolution: "@smithy/middleware-endpoint@npm:4.3.4"
-  dependencies:
-    "@smithy/core": "npm:^3.17.0"
+    "@smithy/core": "npm:^3.17.1"
     "@smithy/middleware-serde": "npm:^4.2.3"
     "@smithy/node-config-provider": "npm:^4.3.3"
     "@smithy/shared-ini-file-loader": "npm:^4.3.3"
@@ -2473,35 +2389,24 @@ __metadata:
     "@smithy/url-parser": "npm:^4.2.3"
     "@smithy/util-middleware": "npm:^4.2.3"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/6a0e8a76fbdd88f6e1190bbf5282e57a4105aa2e771c9e4c2fe6d7765e2654ac9e0b334e3bdf1abacdd14f53879734266b8ed6aa05625a9a180bf157f0ee18d4
+  checksum: 10c0/397cad4fff38b3d388315bac04499eca34f77cd558115d9b621f145d933a851bcac99a6c4c546f43f119f46d1f6abffb25bafdcf124d1851347cacce7017a626
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^4.4.3":
-  version: 4.4.4
-  resolution: "@smithy/middleware-retry@npm:4.4.4"
+"@smithy/middleware-retry@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "@smithy/middleware-retry@npm:4.4.5"
   dependencies:
     "@smithy/node-config-provider": "npm:^4.3.3"
     "@smithy/protocol-http": "npm:^5.3.3"
     "@smithy/service-error-classification": "npm:^4.2.3"
-    "@smithy/smithy-client": "npm:^4.9.0"
+    "@smithy/smithy-client": "npm:^4.9.1"
     "@smithy/types": "npm:^4.8.0"
     "@smithy/util-middleware": "npm:^4.2.3"
     "@smithy/util-retry": "npm:^4.2.3"
     "@smithy/uuid": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/10a00cc54dd792160374daa709d2e3ed9146296de80e19ab0dce26db8de3170bba6c90fc3d2fbc542c8584f9ffa6cfc388c31910ccc245faa1071f8b8966651e
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-serde@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/middleware-serde@npm:4.2.2"
-  dependencies:
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/4d3db5dcce34b08f90af4b150c94fb25c0ceb309ea8cc07686be9dde4ccfaa5f31b6662fcaab4a7f2d4ce2630a26048abc08020e36bacccff8411772b59bb998
+  checksum: 10c0/fe196af3b5e91c4c64649425d51f61133e0776a4cb9ea3151a7aab53dea7abdf19fc7582168b615c0f90be570c0e6c2e048927ea012108b708419b1f62217dc6
   languageName: node
   linkType: hard
 
@@ -2516,16 +2421,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-stack@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/middleware-stack@npm:4.2.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/81b265313f381ff12c223997f04b171f661e58fa3ae3d286990148d9252c784f6bdd9f2c4db747d4eb860fec96c72363d369f7d11bdd8e34fb03ae7e0aba7a09
-  languageName: node
-  linkType: hard
-
 "@smithy/middleware-stack@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/middleware-stack@npm:4.2.3"
@@ -2533,18 +2428,6 @@ __metadata:
     "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/4a2cc539a6850501831a502a35eb135d5801003c3061e71e6cfc2cceba94a4db1a81e0c7f06f867871d20fc9b24868bddec513f3759ca484b299b153adf32dae
-  languageName: node
-  linkType: hard
-
-"@smithy/node-config-provider@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "@smithy/node-config-provider@npm:4.3.2"
-  dependencies:
-    "@smithy/property-provider": "npm:^4.2.2"
-    "@smithy/shared-ini-file-loader": "npm:^4.3.2"
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/a1f5a329e64b738a9cf74f28cad4cd9bd844a2146bce9681d24494a69869e847dbe037bf5ef89508c7b3f234f1c7dff7796e35e747ae675b31e0aa0efd6699a8
   languageName: node
   linkType: hard
 
@@ -2560,39 +2443,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "@smithy/node-http-handler@npm:4.4.1"
-  dependencies:
-    "@smithy/abort-controller": "npm:^4.2.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/querystring-builder": "npm:^4.2.2"
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/126ac736317cc167c5744366bff0efef9e9afffbcc6afb3a70875388be570b7eca2a52c59c6c12d6b990ebe4c90c103209a5b874b3a16c72d5923fc3c0ed3dfa
-  languageName: node
-  linkType: hard
-
-"@smithy/node-http-handler@npm:^4.4.2, @smithy/node-http-handler@npm:~4.4.2":
-  version: 4.4.2
-  resolution: "@smithy/node-http-handler@npm:4.4.2"
+"@smithy/node-http-handler@npm:^4.4.3, @smithy/node-http-handler@npm:~4.4.3":
+  version: 4.4.3
+  resolution: "@smithy/node-http-handler@npm:4.4.3"
   dependencies:
     "@smithy/abort-controller": "npm:^4.2.3"
     "@smithy/protocol-http": "npm:^5.3.3"
     "@smithy/querystring-builder": "npm:^4.2.3"
     "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/60f3d95b03885440ae3acc31f5bacea8fbdd072b8f9b96080887bd24e1c9e697cbc785d8cb5d3eb1eb26746a8c12d2df93924bad255e4adee10fad7476e29202
-  languageName: node
-  linkType: hard
-
-"@smithy/property-provider@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/property-provider@npm:4.2.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/14b49afd41b9c490b8568716aceb0e6e02449a8a3008b11634d593bd0013081296eb8768fd51ef7bf35e5d0cb248895bbfa73a8b15afa6bcf2fb8d001b38149d
+  checksum: 10c0/343ca2d2ce8e8b11f849edaa69b52b439be93cf2351cac78c0c545e41af621b0300eaa32fdeea06e282a6b5801db3b9dc3b339674f7dd427aa1e26fd46968f2a
   languageName: node
   linkType: hard
 
@@ -2606,16 +2466,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^5.3.2":
-  version: 5.3.2
-  resolution: "@smithy/protocol-http@npm:5.3.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/a429e1b058d342aaff0eb9463be4d7f4da1ac12933bf30e202d906f25964e20433d503f4e19fe5ede5989f84096ba5e09cf0c10fd94992c8306dd81aa7d17a95
-  languageName: node
-  linkType: hard
-
 "@smithy/protocol-http@npm:^5.3.3":
   version: 5.3.3
   resolution: "@smithy/protocol-http@npm:5.3.3"
@@ -2623,17 +2473,6 @@ __metadata:
     "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/f94d43aefcabc89b3de881b6d11b40ca46367a938be7cb7ebea85a289d373f18b68453c7374e9d254805b84c336b8654fd2c6bbbf34b3974752de2b0774c7023
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-builder@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/querystring-builder@npm:4.2.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-uri-escape": "npm:^4.2.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/d1a288fd78a01133aca6d6778232f7cf8d8fc423af6eab1604ebd06c547ef403e2d51879a47e19dd37ac72e3cbee0f532362b2ec1528f03580ce01687d047c69
   languageName: node
   linkType: hard
 
@@ -2648,16 +2487,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/querystring-parser@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/querystring-parser@npm:4.2.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/af0f051265aabdefd0e8ad40b39962513ca4d6a6560f30b8129b1ddbcf5965fdc8567024062e146dc234dc952376d3a92cba7ee0660685aa7e6fc9ff851f974d
-  languageName: node
-  linkType: hard
-
 "@smithy/querystring-parser@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/querystring-parser@npm:4.2.3"
@@ -2668,31 +2497,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/service-error-classification@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/service-error-classification@npm:4.2.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-  checksum: 10c0/10e1d9bbe7bb02e0cf20ed83964586dc97016a103d5fd656eb0a31f8d9a6df7049eef26d6b864da0ae2ecb175ddccb5e0bdf091e58282b8bda27f01ac69c08aa
-  languageName: node
-  linkType: hard
-
 "@smithy/service-error-classification@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/service-error-classification@npm:4.2.3"
   dependencies:
     "@smithy/types": "npm:^4.8.0"
   checksum: 10c0/8cd7327515125632a5b7535a9db24ab3f3d733253224d260ac6bf94e04ed3abf99ebd6cfb723d160b3fe49aa87c573dc51775656f4a661939851521e1fd750bb
-  languageName: node
-  linkType: hard
-
-"@smithy/shared-ini-file-loader@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "@smithy/shared-ini-file-loader@npm:4.3.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/3b96d782bf6ea47107799f8befc4be1182ef7db0e98168f1e253c0404e1a53c5b587ccdb09a14c601f105494aa2bf2229822242e37de7fd55263481097f75543
   languageName: node
   linkType: hard
 
@@ -2706,7 +2516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/signature-v4@npm:^5.3.2":
+"@smithy/signature-v4@npm:^5.3.3":
   version: 5.3.3
   resolution: "@smithy/signature-v4@npm:5.3.3"
   dependencies:
@@ -2722,33 +2532,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^4.8.1":
-  version: 4.8.1
-  resolution: "@smithy/smithy-client@npm:4.8.1"
+"@smithy/smithy-client@npm:^4.9.1":
+  version: 4.9.1
+  resolution: "@smithy/smithy-client@npm:4.9.1"
   dependencies:
-    "@smithy/core": "npm:^3.16.1"
-    "@smithy/middleware-endpoint": "npm:^4.3.3"
-    "@smithy/middleware-stack": "npm:^4.2.2"
-    "@smithy/protocol-http": "npm:^5.3.2"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-stream": "npm:^4.5.2"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/3c01450c7d3b43e56781333450e50a8f30afb530acf0a8e8e37b03cf9e534082427e48b9bd4fb31a94791fc9177e12b37fda63eafb0e3ee79c3e7272281add1f
-  languageName: node
-  linkType: hard
-
-"@smithy/smithy-client@npm:^4.9.0":
-  version: 4.9.0
-  resolution: "@smithy/smithy-client@npm:4.9.0"
-  dependencies:
-    "@smithy/core": "npm:^3.17.0"
-    "@smithy/middleware-endpoint": "npm:^4.3.4"
+    "@smithy/core": "npm:^3.17.1"
+    "@smithy/middleware-endpoint": "npm:^4.3.5"
     "@smithy/middleware-stack": "npm:^4.2.3"
     "@smithy/protocol-http": "npm:^5.3.3"
     "@smithy/types": "npm:^4.8.0"
-    "@smithy/util-stream": "npm:^4.5.3"
+    "@smithy/util-stream": "npm:^4.5.4"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/3a4c045b6d81e2d7803aa1cbac6579481c2a6b204d42f92cd832c6b076bb7673afcd3e9c37050049c594992ca3591aa257c54c2a7d06f729d1d7ebe1942f1a6c
+  checksum: 10c0/6b50a5d00e2b68e72e78d08e6d90587159ed80d6fb9a6fb341cc78a55feca9f12157cb309eb8e22ab8fe6508a63ac4bfa2e42cf6f7077a8d571a30cb33232ce8
   languageName: node
   linkType: hard
 
@@ -2761,32 +2556,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^4.7.1":
-  version: 4.7.1
-  resolution: "@smithy/types@npm:4.7.1"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/5e5703d99bf814d78b636a7652229c644759424523b1877d16a61007de250ced27bb119ab37bb0fb31d973ba590717dac03ff1827d2a45a075b0bb037066c90b
-  languageName: node
-  linkType: hard
-
 "@smithy/types@npm:^4.8.0":
   version: 4.8.0
   resolution: "@smithy/types@npm:4.8.0"
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/342173aeaa80b3837dce51c393a3fcab7db9b3ec1481cbc6d00298566076481b88e274c258c2dab54112641d66ab678c7ed7dc2c2a4500ffcf407a6d61c33fd0
-  languageName: node
-  linkType: hard
-
-"@smithy/url-parser@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/url-parser@npm:4.2.2"
-  dependencies:
-    "@smithy/querystring-parser": "npm:^4.2.2"
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/da5bfb3ad9670437cd917c9be7a9f7563a7d59a67d0dd639b306e439cdf1fed651e4d1f8e3ee9f66fafb938668419284e2c3d29fee29b3e8b708c826ddecac2d
   languageName: node
   linkType: hard
 
@@ -2859,34 +2634,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^4.3.2":
-  version: 4.3.3
-  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.3"
+"@smithy/util-defaults-mode-browser@npm:^4.3.4":
+  version: 4.3.4
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.4"
   dependencies:
     "@smithy/property-provider": "npm:^4.2.3"
-    "@smithy/smithy-client": "npm:^4.9.0"
+    "@smithy/smithy-client": "npm:^4.9.1"
     "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/e18e571affd7b580454efbadb28061dfe491bf76faf40a0ace12daf27f439b327b24c621c94e85528c4e6fcd0506087905d3957fb27a88b6f203a16ca7155cd3
+  checksum: 10c0/b3e48214a2f9e3b55995e7b44b4531b37c4e83960582afae8991ba98d2552132e1fc1962408be476ec45301cf03887194d5941cc76db500ad2f4fc748552bfee
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^4.2.3":
-  version: 4.2.4
-  resolution: "@smithy/util-defaults-mode-node@npm:4.2.4"
+"@smithy/util-defaults-mode-node@npm:^4.2.6":
+  version: 4.2.6
+  resolution: "@smithy/util-defaults-mode-node@npm:4.2.6"
   dependencies:
-    "@smithy/config-resolver": "npm:^4.3.3"
+    "@smithy/config-resolver": "npm:^4.4.0"
     "@smithy/credential-provider-imds": "npm:^4.2.3"
     "@smithy/node-config-provider": "npm:^4.3.3"
     "@smithy/property-provider": "npm:^4.2.3"
-    "@smithy/smithy-client": "npm:^4.9.0"
+    "@smithy/smithy-client": "npm:^4.9.1"
     "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/b6507506a6601441ca4a6b31c5041587834f891b5388d6163f2b550da81b6a12838664d897f6a834edad037475db3d4959e9a869d404c844df1b266ca7a17c3e
+  checksum: 10c0/edd0918a5cff0787dd2fadf8aa36ef603922eaff5f3b2ec620c2c522e2bbda127327c26debe26028544ff34d5726004cfbf8c0a90505b657b852989a94f5c8ab
   languageName: node
   linkType: hard
 
-"@smithy/util-endpoints@npm:^3.2.2":
+"@smithy/util-endpoints@npm:^3.2.3":
   version: 3.2.3
   resolution: "@smithy/util-endpoints@npm:3.2.3"
   dependencies:
@@ -2906,16 +2681,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-middleware@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/util-middleware@npm:4.2.2"
-  dependencies:
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/efada57900ece7f000740899a0f38a38844be3968e40379105c1c2a19d88bbda9095e87d50c8837f6d35b4f984ee73617c39db516b3716270b763e3a3b3ed406
-  languageName: node
-  linkType: hard
-
 "@smithy/util-middleware@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/util-middleware@npm:4.2.3"
@@ -2923,17 +2688,6 @@ __metadata:
     "@smithy/types": "npm:^4.8.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e98d461754d849b543a69e6a0fa74448cf00cf0954d6f484f735bcbf6c10a51cf63ad2090bcd8f276c19cbe7c413075ee49e6018cad8c15c3844480fa0efd0a1
-  languageName: node
-  linkType: hard
-
-"@smithy/util-retry@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@smithy/util-retry@npm:4.2.2"
-  dependencies:
-    "@smithy/service-error-classification": "npm:^4.2.2"
-    "@smithy/types": "npm:^4.7.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/7df12a5d81a3047fdd3d1a03b391e2132bc94127eccfbe3c3d74409c0e6d6a4f924845d6f5c78708a49ba28213b177d97e2db9fe397d2851f89995b98d47edf7
   languageName: node
   linkType: hard
 
@@ -2948,35 +2702,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^4.5.2":
-  version: 4.5.2
-  resolution: "@smithy/util-stream@npm:4.5.2"
-  dependencies:
-    "@smithy/fetch-http-handler": "npm:^5.3.3"
-    "@smithy/node-http-handler": "npm:^4.4.1"
-    "@smithy/types": "npm:^4.7.1"
-    "@smithy/util-base64": "npm:^4.3.0"
-    "@smithy/util-buffer-from": "npm:^4.2.0"
-    "@smithy/util-hex-encoding": "npm:^4.2.0"
-    "@smithy/util-utf8": "npm:^4.2.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/aade6b07adfb6cc9e85fbdd3ce70959e95550d849d7f89d87c61148d1189258ee9f2a589c4c7cbd264776db945bef5b6dee76277439c0a9e4ecf9651b07fe383
-  languageName: node
-  linkType: hard
-
-"@smithy/util-stream@npm:^4.5.3":
-  version: 4.5.3
-  resolution: "@smithy/util-stream@npm:4.5.3"
+"@smithy/util-stream@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "@smithy/util-stream@npm:4.5.4"
   dependencies:
     "@smithy/fetch-http-handler": "npm:^5.3.4"
-    "@smithy/node-http-handler": "npm:^4.4.2"
+    "@smithy/node-http-handler": "npm:^4.4.3"
     "@smithy/types": "npm:^4.8.0"
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-buffer-from": "npm:^4.2.0"
     "@smithy/util-hex-encoding": "npm:^4.2.0"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/268c2810308bdde83eb833e179d3c5ffd935ffe5021cb857ce4291c68347fb0ba5409fb806bbff3e455af91d302611970a0d43180795d0c78356ac629a155c8a
+  checksum: 10c0/9c0ea9062b6800a1261524d4268cbbd943e3681367a5c0ff3b3186889b76c28516acfdaf1c47ad71f72a909c796d97204b1e4cd338cd52e54ace808658a826b5
   languageName: node
   linkType: hard
 
@@ -3009,7 +2747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^4.2.2":
+"@smithy/util-waiter@npm:^4.2.3":
   version: 4.2.3
   resolution: "@smithy/util-waiter@npm:4.2.3"
   dependencies:
@@ -3097,13 +2835,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/file-asset-apis@workspace:packages/file-asset-apis"
   dependencies:
-    "@aws-sdk/client-s3": "npm:~3.913.0"
-    "@smithy/node-http-handler": "npm:~4.4.2"
+    "@aws-sdk/client-s3": "npm:~3.917.0"
+    "@smithy/node-http-handler": "npm:~4.4.3"
     "@terascope/scripts": "npm:~1.21.8"
     "@terascope/utils": "npm:~1.10.4"
     "@types/jest": "npm:~30.0.0"
     aws-sdk-client-mock: "npm:~4.1.0"
-    csvtojson: "npm:~2.0.10"
+    csvtojson: "npm:~2.0.13"
     fs-extra: "npm:~11.3.2"
     jest: "npm:~30.2.0"
     jest-extended: "npm:~6.0.0"
@@ -3676,12 +3414,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~24.8.1":
-  version: 24.8.1
-  resolution: "@types/node@npm:24.8.1"
+"@types/node@npm:~24.9.1":
+  version: 24.9.1
+  resolution: "@types/node@npm:24.9.1"
   dependencies:
-    undici-types: "npm:~7.14.0"
-  checksum: 10c0/d185f2f14aa26cc2b482aa730bfc452943f9636df37aad6ceed80aa397f1278f894043336bd72f74c47b3dbef23e772ac9b1a256168984aa8aee26836132d290
+    undici-types: "npm:~7.16.0"
+  checksum: 10c0/c52f8168080ef9a7c3dc23d8ac6061fab5371aad89231a0f6f4c075869bc3de7e89b075b1f3e3171d9e5143d0dda1807c3dab8e32eac6d68f02e7480e7e78576
   languageName: node
   linkType: hard
 
@@ -4695,13 +4433,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bluebird@npm:^3.5.1":
-  version: 3.7.2
-  resolution: "bluebird@npm:3.7.2"
-  checksum: 10c0/680de03adc54ff925eaa6c7bb9a47a0690e8b5de60f4792604aae8ed618c65e6b63a7893b57ca924beaf53eee69c5af4f8314148c08124c550fe1df1add897d2
-  languageName: node
-  linkType: hard
-
 "bowser@npm:^2.11.0":
   version: 2.12.0
   resolution: "bowser@npm:2.12.0"
@@ -5197,16 +4928,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csvtojson@npm:~2.0.10":
-  version: 2.0.10
-  resolution: "csvtojson@npm:2.0.10"
+"csvtojson@npm:~2.0.13":
+  version: 2.0.13
+  resolution: "csvtojson@npm:2.0.13"
   dependencies:
-    bluebird: "npm:^3.5.1"
-    lodash: "npm:^4.17.3"
-    strip-bom: "npm:^2.0.0"
+    lodash: "npm:^4.17.21"
   bin:
-    csvtojson: ./bin/csvtojson
-  checksum: 10c0/0a35e035db845c93768b5e1bf606d2d2ca5dadd36dd974474c6f54ed689fdbbb7fa21b723b2e1eb7fde9aa5d5d1e3e83d2162f1b8cb419fa7e0e196ec263a176
+    csvtojson: bin/csvtojson
+  checksum: 10c0/2bfa01608a6279498dba61dbc6a25179fff3a6842718529ca34ff67da365fc4627329bf8bd621d93504c49cbdb163b812412f9bafbfd9e03ee5e631730a7a8ab
   languageName: node
   linkType: hard
 
@@ -6402,7 +6131,7 @@ __metadata:
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
     "@types/json2csv": "npm:~5.0.7"
-    "@types/node": "npm:~24.8.1"
+    "@types/node": "npm:~24.9.1"
     "@types/node-gzip": "npm:~1.1.3"
     "@types/semver": "npm:~7.7.1"
     eslint: "npm:~9.38.0"
@@ -6465,7 +6194,7 @@ __metadata:
   dependencies:
     "@terascope/file-asset-apis": "npm:~1.1.2"
     "@terascope/job-components": "npm:~1.12.4"
-    csvtojson: "npm:~2.0.10"
+    csvtojson: "npm:~2.0.13"
     fs-extra: "npm:~11.3.2"
     json2csv: "npm:5.0.7"
     lz4-asm: "npm:~0.4.2"
@@ -7643,13 +7372,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-utf8@npm:^0.2.0":
-  version: 0.2.1
-  resolution: "is-utf8@npm:0.2.1"
-  checksum: 10c0/3ed45e5b4ddfa04ed7e32c63d29c61b980ecd6df74698f45978b8c17a54034943bcbffb6ae243202e799682a66f90fef526f465dd39438745e9fe70794c1ef09
-  languageName: node
-  linkType: hard
-
 "is-weakmap@npm:^2.0.2":
   version: 2.0.2
   resolution: "is-weakmap@npm:2.0.2"
@@ -8759,7 +8481,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.3":
+"lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -10809,15 +10531,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-bom@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "strip-bom@npm:2.0.0"
-  dependencies:
-    is-utf8: "npm:^0.2.0"
-  checksum: 10c0/4fcbb248af1d5c1f2d710022b7d60245077e7942079bfb7ef3fc8c1ae78d61e96278525ba46719b15ab12fced5c7603777105bc898695339d7c97c64d300ed0b
-  languageName: node
-  linkType: hard
-
 "strip-bom@npm:^3.0.0":
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
@@ -11421,10 +11134,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~7.14.0":
-  version: 7.14.0
-  resolution: "undici-types@npm:7.14.0"
-  checksum: 10c0/e7f3214b45d788f03c51ceb33817be99c65dae203863aa9386b3ccc47201a245a7955fc721fb581da9c888b6ebad59fa3f53405214afec04c455a479908f0f14
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following dependencies:

## File Assets

- csvtojson: `v2.0.13`

## Workspace

- @types/node: `v24.9.1`

## @terascope/file-asset-apis

- @aws-sdk/client-s3: `v3.917.0`
- @smithy/node-http-handler: `v4.4.3`
- csvtojson: `v2.0.13`