### PR TITLE
fix createHandlerOptions test

### DIFF
--- a/packages/file-asset-apis/test/s3/createS3Client-spec.ts
+++ b/packages/file-asset-apis/test/s3/createS3Client-spec.ts
@@ -299,10 +299,8 @@ describe('createS3Client', () => {
                             + '...\n'
                             + 'iKlsPBRbNdq5cNIuIfPS8emrYMs=\n'
                             + '-----END CERTIFICATE-----'],
-                        defaultPort: 443,
                         noDelay: true,
                         path: null,
-                        protocol: 'https:'
                     })
                 })
             });


### PR DESCRIPTION
This PR updates the `createS3Client.createHandlerOptions` test in file-asset-apis to account for added fields in the `httpsAgent.options` object. New fields were added in this PR: https://github.com/nodejs/node/pull/58980

We now check that options contains the fields we expect, but it won't break if new fields are added.

ref: #1317, https://github.com/terascope/workflows/issues/44