### PR TITLE
Revert minimum teraslice version update

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "file",
-    "version": "4.0.0-rc.0",
+    "version": "4.0.0-rc.1",
     "description": "A set of processors for working with files",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file",
     "displayName": "Asset",
-    "version": "4.0.0-rc.0",
+    "version": "4.0.0-rc.1",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": {
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@terascope/core-utils": "~2.0.0-rc.0",
-        "@terascope/file-asset-apis": "~2.0.0-rc.0",
+        "@terascope/file-asset-apis": "~2.0.0-rc.1",
         "@terascope/job-components": "~2.0.0-rc.1",
         "csvtojson": "~2.0.14",
         "fs-extra": "~11.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file-assets-bundle",
     "displayName": "File Assets Bundle",
-    "version": "4.0.0-rc.0",
+    "version": "4.0.0-rc.1",
     "private": true,
     "description": "A set of teraslice processors for working with files",
     "homepage": "https://github.com/terascope/file-assets",
@@ -39,7 +39,7 @@
     "devDependencies": {
         "@terascope/core-utils": "~2.0.0-rc.0",
         "@terascope/eslint-config": "~1.1.26",
-        "@terascope/file-asset-apis": "~2.0.0-rc.0",
+        "@terascope/file-asset-apis": "~2.0.0-rc.1",
         "@terascope/job-components": "~2.0.0-rc.1",
         "@terascope/scripts": "~2.0.0-rc.0",
         "@types/fs-extra": "~11.0.4",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/file-asset-apis",
     "displayName": "File Asset Apis",
-    "version": "2.0.0-rc.0",
+    "version": "2.0.0-rc.1",
     "description": "file reader and sender apis",
     "homepage": "https://github.com/terascope/file-assets",
     "repository": "git@github.com:terascope/file-assets.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2849,7 +2849,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/file-asset-apis@npm:~2.0.0-rc.0, @terascope/file-asset-apis@workspace:packages/file-asset-apis":
+"@terascope/file-asset-apis@npm:~2.0.0-rc.1, @terascope/file-asset-apis@workspace:packages/file-asset-apis":
   version: 0.0.0-use.local
   resolution: "@terascope/file-asset-apis@workspace:packages/file-asset-apis"
   dependencies:
@@ -5773,7 +5773,7 @@ __metadata:
   dependencies:
     "@terascope/core-utils": "npm:~2.0.0-rc.0"
     "@terascope/eslint-config": "npm:~1.1.26"
-    "@terascope/file-asset-apis": "npm:~2.0.0-rc.0"
+    "@terascope/file-asset-apis": "npm:~2.0.0-rc.1"
     "@terascope/job-components": "npm:~2.0.0-rc.1"
     "@terascope/scripts": "npm:~2.0.0-rc.0"
     "@types/fs-extra": "npm:~11.0.4"
@@ -5832,7 +5832,7 @@ __metadata:
   resolution: "file@workspace:asset"
   dependencies:
     "@terascope/core-utils": "npm:~2.0.0-rc.0"
-    "@terascope/file-asset-apis": "npm:~2.0.0-rc.0"
+    "@terascope/file-asset-apis": "npm:~2.0.0-rc.1"
     "@terascope/job-components": "npm:~2.0.0-rc.1"
     csvtojson: "npm:~2.0.14"
     fs-extra: "npm:~11.3.2"


### PR DESCRIPTION
This PR reverts the minimum teraslice version back to 2.0.0 and bumps file asset and asset bundle to 4.0.0-rc.1 and file-asset-apis to 2.0.0-rc.1