### PR TITLE
Switch workflows back to main branch

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -16,10 +16,10 @@ permissions:
 jobs:
   call-master-asset-build:
     if: github.event.pull_request.merged == true && github.base_ref == 'master'
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@asset-e2e
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@main
     secrets: inherit
 
   call-prerelease-asset-build:
     if: github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/file-assets-v')
-    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@asset-e2e
+    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@main
     secrets: inherit

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@asset-e2e
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@main
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@asset-e2e
+    uses: terascope/workflows/.github/workflows/asset-test.yml@main
     secrets: inherit

--- a/.github/workflows/test-prerelease-asset.yml
+++ b/.github/workflows/test-prerelease-asset.yml
@@ -10,5 +10,5 @@ on:
       - release/file-assets-v*
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@asset-e2e
+    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@main
     secrets: inherit


### PR DESCRIPTION
This PR makes the following changes:

- Changes workflows branch from `asset-e2e` to `main`