### PR TITLE
S3 dedup tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Any manual changes will be lost next time this gets auto-generated. -->
 
 - [file_exporter](./docs/asset/operations/file_exporter)
 - [file_reader](./docs/asset/operations/file_reader)
+- s3_dedup_tracker
 - [s3_exporter](./docs/asset/operations/s3_exporter)
 - [s3_reader](./docs/asset/operations/s3_reader)
 

--- a/asset/src/index.ts
+++ b/asset/src/index.ts
@@ -14,6 +14,9 @@ import FileReaderAPISchema from '../src/file_reader_api/schema';
 import FileSenderAPI from '../src/file_sender_api/api';
 import FileSenderAPISchema from '../src/file_sender_api/schema';
 
+import S3DedupTracker from '../src/s3_dedup_tracker/processor';
+import S3DedupTrackerSchema from '../src/s3_dedup_tracker/schema';
+
 import S3Exporter from '../src/s3_exporter/processor';
 import S3ExporterSchema from '../src/s3_exporter/schema';
 
@@ -26,9 +29,6 @@ import S3ReaderAPISchema from '../src/s3_reader_api/schema';
 
 import S3SenderAPI from '../src/s3_sender_api/api';
 import S3SenderAPISchema from '../src/s3_sender_api/schema';
-
-import S3DedupTracker from '../src/s3_dedup_tracker/processor';
-import S3DedupTrackerSchema from '../src/s3_dedup_tracker/schema';
 
 export const ASSETS = {
     file_exporter: {
@@ -48,6 +48,10 @@ export const ASSETS = {
         API: FileSenderAPI,
         Schema: FileSenderAPISchema,
     },
+    s3_dedup_tracker: {
+        Processor: S3DedupTracker,
+        Schema: S3DedupTrackerSchema,
+    },
     s3_exporter: {
         Processor: S3Exporter,
         Schema: S3ExporterSchema,
@@ -64,9 +68,5 @@ export const ASSETS = {
     s3_sender_api: {
         API: S3SenderAPI,
         Schema: S3SenderAPISchema,
-    },
-    s3_dedup_tracker: {
-        Processor: S3DedupTracker,
-        Schema: S3DedupTrackerSchema,
     },
 };

--- a/asset/src/index.ts
+++ b/asset/src/index.ts
@@ -27,6 +27,9 @@ import S3ReaderAPISchema from '../src/s3_reader_api/schema';
 import S3SenderAPI from '../src/s3_sender_api/api';
 import S3SenderAPISchema from '../src/s3_sender_api/schema';
 
+import S3DedupTracker from '../src/s3_dedup_tracker/processor';
+import S3DedupTrackerSchema from '../src/s3_dedup_tracker/schema';
+
 export const ASSETS = {
     file_exporter: {
         Processor: FileExporter,
@@ -61,5 +64,9 @@ export const ASSETS = {
     s3_sender_api: {
         API: S3SenderAPI,
         Schema: S3SenderAPISchema,
+    },
+    s3_dedup_tracker: {
+        Processor: S3DedupTracker,
+        Schema: S3DedupTrackerSchema,
     },
 };

--- a/asset/src/s3_dedup_tracker/interfaces.ts
+++ b/asset/src/s3_dedup_tracker/interfaces.ts
@@ -1,0 +1,10 @@
+import { OpConfig } from '@terascope/job-components';
+
+export interface S3DedupTrackerConfig extends OpConfig {
+    track_field: string;
+    s3_bucket: string;
+    report_path: string;
+    report_interval: number;
+    report_interval_ms: number;
+    _connection: string;
+}

--- a/asset/src/s3_dedup_tracker/interfaces.ts
+++ b/asset/src/s3_dedup_tracker/interfaces.ts
@@ -6,5 +6,6 @@ export interface S3DedupTrackerConfig extends OpConfig {
     report_path: string;
     report_interval: number;
     report_interval_ms: number;
+    record_fields: string;
     _connection: string;
 }

--- a/asset/src/s3_dedup_tracker/processor.ts
+++ b/asset/src/s3_dedup_tracker/processor.ts
@@ -39,7 +39,8 @@ export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig>
         this.s3Client = s3Client;
         // Parse the comma-separated record_fields config once at init time
         if (this.opConfig.record_fields) {
-            this.recordFields = this.opConfig.record_fields.split(',').map((f) => f.trim()).filter(Boolean);
+            this.recordFields = this.opConfig.record_fields.split(',').map((f) => f.trim())
+                .filter(Boolean);
         }
         // Seed the flush timer so the first interval is measured from job start
         this.lastFlushTime = Date.now();
@@ -63,7 +64,12 @@ export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig>
                                 .map((f) => [f, record[f]] as [string, unknown])
                         )
                         : undefined;
-                    this.counts.set(key, { count: 1, sample: Object.keys(sample ?? {}).length > 0 ? sample : undefined });
+                    this.counts.set(
+                        key, {
+                            count: 1,
+                            sample: Object.keys(sample ?? {}).length > 0 ? sample : undefined
+                        }
+                    );
                 } else {
                     entry.count++;
                 }
@@ -108,7 +114,9 @@ export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig>
      * holds the most recent cumulative snapshot.
      */
     private async writeReport(): Promise<void> {
-        type DuplicateEntry = { value: string; record_sample?: Record<string, unknown>; count: number };
+        type DuplicateEntry = {
+            value: string; record_sample?: Record<string, unknown>; count: number;
+        };
         const duplicates: DuplicateEntry[] = [];
 
         // Collect only values that appeared more than once
@@ -134,7 +142,7 @@ export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig>
         await putS3Object(this.s3Client, {
             Bucket: this.opConfig.s3_bucket,
             Key: this.opConfig.report_path,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
             Body: Buffer.from(JSON.stringify(report, null, 2)) as any,
             ContentType: 'application/json'
         });

--- a/asset/src/s3_dedup_tracker/processor.ts
+++ b/asset/src/s3_dedup_tracker/processor.ts
@@ -1,0 +1,120 @@
+import { DataEntity } from '@terascope/core-utils';
+import { BatchProcessor } from '@terascope/job-components';
+import { putS3Object, S3Client } from '@terascope/file-asset-apis';
+import { S3DedupTrackerConfig } from './interfaces.js';
+
+/**
+ * S3DedupTracker is a pass-through BatchProcessor that counts how often each
+ * unique value of a configured field (`track_field`) appears across all records
+ * it processes. It does NOT filter or modify the data stream — every record is
+ * returned unchanged. Instead, it accumulates counts in memory and periodically
+ * writes a JSON dedup report to a configured S3 key, overwriting the same key
+ * on each flush so the report always reflects cumulative totals.
+ *
+ * Flushing is triggered by either:
+ *   - count-based: every `report_interval` slices (if > 0)
+ *   - time-based:  whenever `report_interval_ms` ms have elapsed since the last
+ *                  flush (if > 0)
+ * A final flush always occurs on job shutdown to capture any remaining data.
+ */
+export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig> {
+    // Cumulative frequency map: field value → number of times seen across all slices
+    private counts = new Map<string, number>();
+    // Total number of slices received since the job started
+    private slicesProcessed = 0;
+    private s3Client!: S3Client;
+    // Wall-clock timestamp of the last report write, used for time-based flushing
+    private lastFlushTime = 0;
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+        // Obtain a cached S3 client from the Terafoundation connection registry
+        const { client: s3Client } = await this.context.apis.foundation.createClient({
+            endpoint: this.opConfig._connection,
+            type: 's3',
+            cached: true
+        });
+        this.s3Client = s3Client;
+        // Seed the flush timer so the first interval is measured from job start
+        this.lastFlushTime = Date.now();
+    }
+
+    async onBatch(slice: DataEntity[]): Promise<DataEntity[]> {
+        const field = this.opConfig.track_field;
+
+        // Accumulate value frequencies from this slice into the running totals
+        for (const record of slice) {
+            const val = record[field];
+            if (val != null) {
+                const key = String(val);
+                this.counts.set(key, (this.counts.get(key) ?? 0) + 1);
+            }
+        }
+
+        this.slicesProcessed++;
+
+        // Count-based flush: trigger after every N slices when report_interval is set
+        const countFlush = this.opConfig.report_interval > 0
+            && this.slicesProcessed % this.opConfig.report_interval === 0;
+
+        // Time-based flush: trigger if enough wall-clock time has passed since the last write
+        const timeoutFlush = this.opConfig.report_interval_ms > 0
+            && (Date.now() - this.lastFlushTime) >= this.opConfig.report_interval_ms;
+
+        if (countFlush || timeoutFlush) {
+            await this.writeReport();
+            // reset the timer whether flush was triggered by count or timeout
+            this.lastFlushTime = Date.now();
+        }
+
+        // Pass the slice through unmodified — this processor is observation-only
+        return slice;
+    }
+
+    async shutdown(): Promise<void> {
+        // Always write a final report on shutdown to capture any un-flushed counts
+        await this.writeReport();
+        await super.shutdown();
+    }
+
+    /**
+     * Builds and uploads the dedup report to S3.
+     *
+     * The report lists every field value that appeared more than once, sorted
+     * from highest to lowest count. It also includes summary statistics:
+     * the total number of unique values seen and the total number of those
+     * that were duplicated.
+     *
+     * The S3 key is always overwritten, so the object at `report_path` always
+     * holds the most recent cumulative snapshot.
+     */
+    private async writeReport(): Promise<void> {
+        const duplicates: { value: string; count: number }[] = [];
+
+        // Collect only values that appeared more than once
+        for (const [value, count] of this.counts) {
+            if (count > 1) {
+                duplicates.push({ value, count });
+            }
+        }
+
+        // Sort descending by count so the most-duplicated values appear first
+        duplicates.sort((a, b) => b.count - a.count);
+
+        const report = {
+            generated_at: new Date().toISOString(),
+            slices_processed: this.slicesProcessed,
+            unique_count: this.counts.size,
+            duplicate_count: duplicates.length,
+            duplicates
+        };
+
+        await putS3Object(this.s3Client, {
+            Bucket: this.opConfig.s3_bucket,
+            Key: this.opConfig.report_path,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            Body: Buffer.from(JSON.stringify(report, null, 2)) as any,
+            ContentType: 'application/json'
+        });
+    }
+}

--- a/asset/src/s3_dedup_tracker/processor.ts
+++ b/asset/src/s3_dedup_tracker/processor.ts
@@ -18,8 +18,10 @@ import { S3DedupTrackerConfig } from './interfaces.js';
  * A final flush always occurs on job shutdown to capture any remaining data.
  */
 export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig> {
-    // Cumulative frequency map: field value → number of times seen across all slices
-    private counts = new Map<string, number>();
+    // Cumulative frequency map: field value → count and optional first-seen sample fields
+    private counts = new Map<string, { count: number; sample?: Record<string, unknown> }>();
+    // Parsed list of extra field names to capture per tracked value (empty = disabled)
+    private recordFields: string[] = [];
     // Total number of slices received since the job started
     private slicesProcessed = 0;
     private s3Client!: S3Client;
@@ -35,6 +37,10 @@ export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig>
             cached: true
         });
         this.s3Client = s3Client;
+        // Parse the comma-separated record_fields config once at init time
+        if (this.opConfig.record_fields) {
+            this.recordFields = this.opConfig.record_fields.split(',').map((f) => f.trim()).filter(Boolean);
+        }
         // Seed the flush timer so the first interval is measured from job start
         this.lastFlushTime = Date.now();
     }
@@ -47,7 +53,20 @@ export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig>
             const val = record[field];
             if (val != null) {
                 const key = String(val);
-                this.counts.set(key, (this.counts.get(key) ?? 0) + 1);
+                const entry = this.counts.get(key);
+                if (entry == null) {
+                    // First occurrence — capture sample fields if configured
+                    const sample = this.recordFields.length > 0
+                        ? Object.fromEntries(
+                            this.recordFields
+                                .filter((f) => record[f] != null)
+                                .map((f) => [f, record[f]] as [string, unknown])
+                        )
+                        : undefined;
+                    this.counts.set(key, { count: 1, sample: Object.keys(sample ?? {}).length > 0 ? sample : undefined });
+                } else {
+                    entry.count++;
+                }
             }
         }
 
@@ -89,12 +108,15 @@ export default class S3DedupTracker extends BatchProcessor<S3DedupTrackerConfig>
      * holds the most recent cumulative snapshot.
      */
     private async writeReport(): Promise<void> {
-        const duplicates: { value: string; count: number }[] = [];
+        type DuplicateEntry = { value: string; record_sample?: Record<string, unknown>; count: number };
+        const duplicates: DuplicateEntry[] = [];
 
         // Collect only values that appeared more than once
-        for (const [value, count] of this.counts) {
+        for (const [value, { count, sample }] of this.counts) {
             if (count > 1) {
-                duplicates.push({ value, count });
+                const entry: DuplicateEntry = { value, count };
+                if (sample != null) entry.record_sample = sample;
+                duplicates.push(entry);
             }
         }
 

--- a/asset/src/s3_dedup_tracker/schema.ts
+++ b/asset/src/s3_dedup_tracker/schema.ts
@@ -37,6 +37,11 @@ export default class Schema extends BaseSchema<S3DedupTrackerConfig> {
                     }
                 }
             },
+            record_fields: {
+                doc: 'Comma-separated list of record fields to capture as a sample alongside each duplicate entry (e.g. "foo,unique_field"). The values are taken from the first occurrence of each tracked value. Omitted from report when empty.',
+                default: '',
+                format: 'optional_string'
+            },
             _connection: {
                 doc: 'The Terafoundation S3 connection to use',
                 default: 'default',

--- a/asset/src/s3_dedup_tracker/schema.ts
+++ b/asset/src/s3_dedup_tracker/schema.ts
@@ -1,0 +1,47 @@
+import { BaseSchema } from '@terascope/job-components';
+import { S3DedupTrackerConfig } from './interfaces.js';
+
+export default class Schema extends BaseSchema<S3DedupTrackerConfig> {
+    build(): Record<string, any> {
+        return {
+            track_field: {
+                doc: 'The field on each incoming record whose value is tracked for uniqueness',
+                default: null,
+                format: 'required_string'
+            },
+            s3_bucket: {
+                doc: 'S3 bucket where the dedup report will be written',
+                default: null,
+                format: 'required_string'
+            },
+            report_path: {
+                doc: 'S3 key for the report file (e.g. "reports/dedup-report.json"). The same key is overwritten on each flush.',
+                default: null,
+                format: 'required_string'
+            },
+            report_interval: {
+                doc: 'Write the report every N slices. Set to 0 to disable count-based flushing (report is still written on job shutdown).',
+                default: 100,
+                format: (val: unknown): void => {
+                    if (typeof val !== 'number' || !Number.isInteger(val) || val < 0) {
+                        throw new Error('report_interval must be a non-negative integer');
+                    }
+                }
+            },
+            report_interval_ms: {
+                doc: 'Write the report if this many milliseconds have elapsed since the last flush. The timer resets whenever a count-based flush occurs. Set to 0 to disable.',
+                default: 0,
+                format: (val: unknown): void => {
+                    if (typeof val !== 'number' || !Number.isInteger(val) || val < 0) {
+                        throw new Error('report_interval_ms must be a non-negative integer');
+                    }
+                }
+            },
+            _connection: {
+                doc: 'The Terafoundation S3 connection to use',
+                default: 'default',
+                format: 'optional_string'
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR makes the following changes:

- Adds a new `s3_dedup_tracker` BatchProcessor that tracks the ammount of unique values for a configured field across all records in a job, without modifying or filtering any data
- The processor writes a JSON report to a configured S3 bucket/path, overwriting the same key on each flush so the report always reflects the total
  - An example object of the Json:
 ```json
{
  "generated_at": "2026-04-08T22:09:53.989Z",
  "slices_processed": 169,
  "unique_count": 9457129,
  "duplicate_count": 25734,
  "duplicates": [
    {
      "value": "953360",
      "count": 2,
      "record_sample": {
        "slice_number": 16,
        "unique_id": 953360
      }
    },
```

The example above was used with the following job:
```json
{
    "name": "j-kafka-s3-dedup",
    "workers": 1,
    "lifecycle": "persistent",
    "log_level": "debug",
    "assets": [
        "37467ae9914a285686830ab4d4618ffa89084b43",
        "1ffc71355b5347162189a80c40e34dc01fd730ae"
    ],
    "apis": [
        {
            "_name": "kafka_reader_api",
            "topic": "dest-v12",
            "group": "group-v1",
            "size": 60000,
            "max_poll_interval": 600000
        }
    ],
    "operations": [
        {
            "_op": "kafka_reader",
            "_api_name": "kafka_reader_api"
        },
        {
            "_op": "s3_dedup_tracker",
            "track_field": "unique_id",
            "s3_bucket": "my-reports-bucket",
            "report_path": "reports/dedup-report-dest-v12.json",
            "report_interval": 100,
            "report_interval_ms": 60000,
            "record_fields": "slice_number,unique_id",
            "_connection": "default"
        }
    ]
}

```
- Supports the following features:
  - Count-based flushing (every report_interval slices) and time-based flushing (every report_interval_ms milliseconds), with a final flush always triggered on job shutdown                                                                   
  - Optional `record_fields` config to capture sample field values from the first occurrence of each tracked value, included in the report alongside duplicate entries