### PR TITLE
Add TERASLICE_DOCKER_VOLUME_PATHS to e2e command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "test": "ts-scripts test asset -- --testPathIgnorePatterns=test/e2e",
         "test:all": "ts-scripts test -- --testPathIgnorePatterns=test/e2e",
         "test:debug": "ts-scripts test --debug asset -- --testPathIgnorePatterns=test/e2e",
-        "test:e2e": "earl assets build --overwrite && ASSET_ZIP_PATH=$(./scripts/asset-zip-path.sh) TEST_TERASLICE=true ts-scripts test -- --testPathPatterns=test/e2e",
+        "test:e2e": "earl assets build --overwrite && ASSET_ZIP_PATH=$(./scripts/asset-zip-path.sh) TERASLICE_DOCKER_VOLUME_PATHS=$(pwd)/packages/file-asset-apis TEST_TERASLICE=true ts-scripts test -- --testPathPatterns=test/e2e",
         "test:encrypted": "ENCRYPT_MINIO=true ts-scripts test -- --testPathPatterns='createS3Client-spec.ts|s3-fetcher-spec.ts|s3-helpers-spec.ts|s3-large-spec.ts|s3-sender-spec.ts|s3_exporter/processor-spec.ts|s3_reader/fetcher-spec.ts|s3_reader/job-spec.ts|s3_reader/slicer-spec.ts|s3_reader_api/api-spec.ts|s3_sender_api/api-spec.ts'",
         "test:watch": "ts-scripts test --watch asset -- --testPathIgnorePatterns=test/e2e"
     },
@@ -40,7 +40,7 @@
         "@terascope/eslint-config": "~1.2.1",
         "@terascope/file-asset-apis": "workspace:~",
         "@terascope/job-components": "~2.13.1",
-        "@terascope/scripts": "~2.16.1",
+        "@terascope/scripts": "~2.17.2",
         "@terascope/types": "~2.11.0",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -32,7 +32,7 @@
         "node-gzip": "~1.1.2"
     },
     "devDependencies": {
-        "@terascope/scripts": "~2.16.1",
+        "@terascope/scripts": "~2.17.2",
         "@terascope/types": "~2.11.0",
         "@types/jest": "~30.0.0",
         "aws-sdk-client-mock": "~4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ~2.13.1
         version: 2.13.1
       '@terascope/scripts':
-        specifier: ~2.16.1
-        version: 2.16.1(typescript@5.9.3)
+        specifier: ~2.17.2
+        version: 2.17.2(typescript@5.9.3)
       '@terascope/types':
         specifier: ~2.11.0
         version: 2.11.0
@@ -142,8 +142,8 @@ importers:
         version: 1.1.2
     devDependencies:
       '@terascope/scripts':
-        specifier: ~2.16.1
-        version: 2.16.1(typescript@5.9.3)
+        specifier: ~2.17.2
+        version: 2.17.2(typescript@5.9.3)
       '@terascope/types':
         specifier: ~2.11.0
         version: 2.11.0
@@ -825,6 +825,10 @@ packages:
     resolution: {integrity: sha512-YdIEwfiFEFZ5llMarZeKHCFJIPIsfJ82mabeyXViGldJWfO2ke9W2B1T13Q95M72lmxq2F9+A5/j1V/NpyOPfw==}
     engines: {node: '>=22.0.0', pnpm: '>=11.3.0'}
 
+  '@terascope/core-utils@2.12.1':
+    resolution: {integrity: sha512-5PJHQ2T7wwhmDfKaWfTB/OXbOsiulEIuVooy7cvkchDV2wuDGNnlAPRgEb809+ih2qwZ8lHQfTetl9UwF2mI1A==}
+    engines: {node: '>=22.0.0', pnpm: '>=11.3.0'}
+
   '@terascope/eslint-config@1.2.1':
     resolution: {integrity: sha512-w6tQ710IlWFqjUcNv45AVqjOmZfHQvxC56FMbTik3+ogJJneNPej43N8pacxtFzjNeh4R5Ro6iCbWbJSvn9GHw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
@@ -838,8 +842,8 @@ packages:
     resolution: {integrity: sha512-9JH+DK3xcK6FmIDka4nlnSkDrelvbnWoBhXHqCJQPFaTIgZi3wKkIzrAYD9JYlzEXHH/iLPsc4MPAQOnLHdlIQ==}
     engines: {node: '>=22.0.0', pnpm: '>=11.3.0'}
 
-  '@terascope/scripts@2.16.1':
-    resolution: {integrity: sha512-EnRho5Sb5sTfCkqn1pbX5E6kMyuOYwnag6qzkh+MYRMuVtYCSy7z0Y4FPsLeSg8T4Wegqg7VNQV+nSioNml1Ug==}
+  '@terascope/scripts@2.17.2':
+    resolution: {integrity: sha512-IQIxopyxSGzFyKF3+XbeAZyND4GqcLfpPCLz1uAE6qhYp2tS+Krys3+ZS4h7ahTn/1FKgjycJEq+Mv3BFFCNbg==}
     engines: {node: '>=22.0.0', pnpm: '>=11.3.0'}
     hasBin: true
     peerDependencies:
@@ -851,6 +855,10 @@ packages:
   '@terascope/types@2.11.0':
     resolution: {integrity: sha512-Anjy9iebvs33CSRGgd8AGXEHs2AkRwYXHpuvG2ZMV1WWaJvW0T/+llNeTvfQZ3Xo8O5yV7xVIqGqsI9CZbHLAA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.25.0'}
+
+  '@terascope/types@2.12.0':
+    resolution: {integrity: sha512-bxeBOGLQaM33JLuwD2YFyIs+FFh+WvIE1eg+4qv0SWJDrWwZ5fHmAnhDPt1bS1p4wATo76VDrDcKmuMnQzrAIQ==}
+    engines: {node: '>=22.0.0', pnpm: '>=11.3.0'}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -1580,6 +1588,9 @@ packages:
 
   date-fns@4.2.1:
     resolution: {integrity: sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   datemath-parser@1.0.6:
     resolution: {integrity: sha512-TEB1YBiGnLAn8lG8ZRf88NCHEERo04xdi1zVGSb//X4nQZs9yqLX7ZM2Ra1PIx+ivnT6j596c8p9QmUX4Y+ddg==}
@@ -2666,6 +2677,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   jsep@1.4.0:
     resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
     engines: {node: '>= 10.16.0'}
@@ -3453,9 +3468,9 @@ packages:
   sort-object-keys@2.1.0:
     resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
 
-  sort-package-json@3.6.1:
-    resolution: {integrity: sha512-Chgejw1+10p2D0U2tB7au1lHtz6TkFnxmvZktyBCRyV0GgmF6nl1IxXxAsPtJVsUyg/fo+BfCMAVVFUVRkAHrQ==}
-    engines: {node: '>=20'}
+  sort-package-json@4.0.0:
+    resolution: {integrity: sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==}
+    engines: {node: '>=22'}
     hasBin: true
 
   source-map-support@0.5.13:
@@ -3736,8 +3751,8 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typedoc-plugin-markdown@4.11.0:
-    resolution: {integrity: sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==}
+  typedoc-plugin-markdown@4.12.0:
+    resolution: {integrity: sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==}
     engines: {node: '>= 18'}
     peerDependencies:
       typedoc: 0.28.x
@@ -4777,7 +4792,7 @@ snapshots:
       form-data: 4.0.5
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       jsonpath-plus: 10.4.0
       node-fetch: 2.7.0
       openid-client: 6.8.4
@@ -4971,6 +4986,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@terascope/core-utils@2.12.1':
+    dependencies:
+      '@terascope/types': 2.12.0
+      awesome-phonenumber: 7.8.0
+      bunyan: 1.8.15
+      date-fns: 4.4.0
+      date-fns-tz: 3.2.0(date-fns@4.4.0)
+      datemath-parser: 1.0.6
+      debug: 4.4.3
+      is-plain-object: 5.0.0
+      js-string-escape: 1.0.1
+      kind-of: 6.0.3
+      lodash-es: 4.18.1
+      mnemonist: 0.40.4
+      moment: 2.30.1
+      ms: 2.1.3
+      p-map: 7.0.4
+      shallow-clone: 3.0.1
+      validator: 13.15.35
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@terascope/eslint-config@1.2.1(jest@30.4.2(@types/node@25.9.2)(node-notifier@10.0.1))':
     dependencies:
       '@eslint/compat': 2.0.5(eslint@9.39.4)
@@ -5018,16 +5056,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@terascope/scripts@2.16.1(typescript@5.9.3)':
+  '@terascope/scripts@2.17.2(typescript@5.9.3)':
     dependencies:
       '@kubernetes/client-node': 1.4.0
-      '@terascope/core-utils': 2.11.1
+      '@terascope/core-utils': 2.12.1
       execa: 9.6.1
       fs-extra: 11.3.5
       globby: 16.2.0
       got: 15.0.5
       ip: 2.0.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       kafkajs: 2.2.4
       micromatch: 4.0.8
       mnemonist: 0.40.4
@@ -5037,10 +5075,10 @@ snapshots:
       package-up: 5.0.0
       semver: 7.8.2
       signale: 1.4.0
-      sort-package-json: 3.6.1
+      sort-package-json: 4.0.0
       toposort: 2.0.2
       typedoc: 0.28.19(typescript@5.9.3)
-      typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
+      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.19(typescript@5.9.3))
       yaml: 2.9.0
       yargs: 18.0.0
     optionalDependencies:
@@ -5055,6 +5093,10 @@ snapshots:
       - utf-8-validate
 
   '@terascope/types@2.11.0':
+    dependencies:
+      prom-client: 15.1.3
+
+  '@terascope/types@2.12.0':
     dependencies:
       prom-client: 15.1.3
 
@@ -5274,7 +5316,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5826,7 +5868,13 @@ snapshots:
     dependencies:
       date-fns: 4.2.1
 
+  date-fns-tz@3.2.0(date-fns@4.4.0):
+    dependencies:
+      date-fns: 4.4.0
+
   date-fns@4.2.1: {}
+
+  date-fns@4.4.0: {}
 
   datemath-parser@1.0.6:
     dependencies:
@@ -7271,6 +7319,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsep@1.4.0: {}
 
   jsesc@3.1.0: {}
@@ -8036,7 +8088,7 @@ snapshots:
 
   sort-object-keys@2.1.0: {}
 
-  sort-package-json@3.6.1:
+  sort-package-json@4.0.0:
     dependencies:
       detect-indent: 7.0.2
       detect-newline: 4.0.1
@@ -8396,7 +8448,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)):
+  typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
       typedoc: 0.28.19(typescript@5.9.3)
 


### PR DESCRIPTION
This PR makes the following changes:

- Adds `TERASLICE_DOCKER_VOLUME_PATHS` to e2e command
  - This fixes https://github.com/terascope/kafka-assets/issues/1160
  - This feature was introduced in https://github.com/terascope/teraslice/pull/4468