### PR TITLE
Bump minimum_teraslice_version to 3.15.0

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -2,5 +2,5 @@
     "name": "file",
     "version": "4.1.2",
     "description": "A set of processors for working with files",
-    "minimum_teraslice_version": "3.0.0"
+    "minimum_teraslice_version": "3.15.0"
 }

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "file",
-    "version": "4.1.2",
+    "version": "4.2.0",
     "description": "A set of processors for working with files",
     "minimum_teraslice_version": "3.15.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file",
     "displayName": "Asset",
-    "version": "4.1.2",
+    "version": "4.2.0",
     "private": true,
     "description": "A set of processors for working with files",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "file-assets-bundle",
     "displayName": "File Assets Bundle",
-    "version": "4.1.2",
+    "version": "4.2.0",
     "private": true,
     "description": "A set of teraslice processors for working with files",
     "homepage": "https://github.com/terascope/file-assets",

--- a/packages/file-asset-apis/package.json
+++ b/packages/file-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/file-asset-apis",
     "displayName": "File Asset Apis",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "file reader and sender apis",
     "homepage": "https://github.com/terascope/file-assets",
     "repository": "git@github.com:terascope/file-assets.git",


### PR DESCRIPTION
This PR makes the following changes:

- Bumps `minimum_teraslice_version` from `v3.0.0` to `v3.15.0`
- Bumps File Assets from `v4.1.2` to `v4.2.0`

ref to issue https://github.com/terascope/teraslice/issues/4509